### PR TITLE
MINOR: README: add warning about comma in value string

### DIFF
--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -111,7 +111,7 @@ helm install my-ingress3 haproxytech/kubernetes-ingress \
   --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-cross-zone-load-balancing-enabled"="true"
 ```
 
-***NOTE***: With helm `--set` it is needed to put quotes and escape dots in the annotation key. 
+***NOTE***: With helm `--set` it is needed to put quotes and escape dots in the annotation key and commas in the value string. 
 
 ### Using values from YAML file
 


### PR DESCRIPTION
When using helm cli  with `--set` parameters, one also need to escape
commas ',' in the value string, such as:

helm upgrade syslog haproxytech/kubernetes-ingress \
  --set controller.config."syslog-server"="address:127.0.0.1\, facility:local0\, format:raw\, level:notice"

otherwise such error is returned:
  Error: failed parsing --set data: key " format:raw, level:notice" has no value