### PR TITLE
New release 0.5.0 including publishService value

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 0.4.2
+version: 0.5.0
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/_helpers.tpl
+++ b/kubernetes-ingress/templates/_helpers.tpl
@@ -90,3 +90,17 @@ Create a default fully qualified default cert secret name.
 {{/*
 Expand the name of the chart.
 */}}
+
+{{/*
+Construct the path for the publish-service.
+
+By default this will use the <namespace>/<service-name> matching the controller's service name.
+
+Users can provide an override for an explicit service they want to use via `.Values.controller.publishService.pathOverride`
+
+*/}}
+{{- define "kubernetes-ingress.publishServicePath" -}}
+{{- $defServicePath := printf "%s/%s" .Release.Namespace (include "kubernetes-ingress.fullname" .) -}}
+{{- $servicePath := default $defServicePath .Values.controller.publishService.pathOverride }}
+{{- print $servicePath | trunc 63 |trimSuffix "-" -}}
+{{- end -}}

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -65,6 +65,9 @@ spec:
 {{- if .Values.controller.ingressClass }}
           - --ingress.class={{ .Values.controller.ingressClass }}
 {{- end }}
+{{- if .Values.controller.publishService.enabled }}
+          - --publish-service={{ template "kubernetes-ingress.publishServicePath" . }}
+{{- end }}
 {{- range .Values.controller.extraArgs }}
           - {{ . }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -57,6 +57,9 @@ spec:
 {{- if .Values.controller.ingressClass }}
           - --ingress.class={{ .Values.controller.ingressClass }}
 {{- end }}
+{{- if .Values.controller.publishService.enabled }}
+          - --publish-service={{ template "kubernetes-ingress.publishServicePath" . }}
+{{- end }}
 {{- range .Values.controller.extraArgs }}
           - {{ . }}
 {{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -112,6 +112,15 @@ controller:
   #   rate-limit-size: "100k"
   #   syslogServer: "port:514, address:192.168.122.1, facility:local0"
 
+  ## Mirrors the address of the service's endpoints to the
+  ## load-balancer status of all Ingress objects it satisfies.
+  publishService:
+    enabled: false
+    ##
+    ## Override of the publish service
+    ## Must be <namespace>/<service_name>
+    pathOverride: ""
+
   ## Controller Service configuration
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
   service:


### PR DESCRIPTION
MINOR: add publishService

When enabled the <namespace>/<service-name> matching the controller's
service will be used by default, unless this is overriden by
pathOverride.