### PR TITLE
Fix to enable disabling hostPorts

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -44,7 +44,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "kubernetes-ingress.serviceAccountName" . }}
+      {{- if $useHostPort }}
       hostNetwork: true
+      {{- end }}
 {{- if .Values.controller.imageCredentials.registry }}
       imagePullSecrets:
       - name: {{ template "kubernetes-ingress.fullname" . }}


### PR DESCRIPTION
Add a conditional to remove hostNetwork when hostPorts are disabled to prevent automatic creation of hostPort records regardless of their presence in the template.

Fixes #3 

Signed-off-by: Daniel Sullivan <dsullivan@charm.co.jp>