### PR TITLE
MINOR: Expose ports for additional TCP services

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -84,6 +84,14 @@ spec:
               hostPort: {{ index $hostPorts $key | default $value }}
               {{- end }}
           {{- end }}
+          {{- range .Values.controller.service.tcpPorts }}
+            - name: {{ . }}-tcp
+              containerPort: {{ . }}
+              protocol: TCP
+              {{- if $useHostPort }}
+              hostPort: {{ . }}
+              {{- end }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -72,6 +72,11 @@ spec:
               containerPort: {{ $value }}
               protocol: TCP
           {{- end }}
+          {{- range .Values.controller.service.tcpPorts }}
+            - name: "{{ . }}-tcp"
+              containerPort: {{ . }}
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -47,6 +47,12 @@ spec:
       port: {{ .Values.controller.service.ports.stat }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.stat }}
+  {{- range .Values.controller.service.tcpPorts }}
+    - name: "{{ . }}-tcp"
+      port: {{ . }}
+      protocol: TCP
+      targetPort: {{ . }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -153,6 +153,11 @@ controller:
       https: https
       stat: stat
 
+    # Additional tcp ports to expose
+    # This is especially useful for TCP services:
+    # https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/controller.md
+    tcpPorts: []
+
     ## Expose service via external IPs that route to one or more cluster nodes
     externalIPs: []
 


### PR DESCRIPTION
Make the Kubernetes service of the controller expose additional ports
via tcpPorts param.
This is particularly useful when the HAProxy ingress controller is used
to handle TCP services.