### PR TITLE
Add release.Namespace in meta

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 0.8.2
+version: 0.9.0
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/controller-configmap.yaml
+++ b/kubernetes-ingress/templates/controller-configmap.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -21,6 +21,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
+++ b/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
@@ -19,6 +19,7 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   name: {{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -19,6 +19,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/controller-pullsecret.yaml
+++ b/kubernetes-ingress/templates/controller-pullsecret.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/controller-serviceaccount.yaml
+++ b/kubernetes-ingress/templates/controller-serviceaccount.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kubernetes-ingress.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -18,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}

--- a/kubernetes-ingress/templates/default-backend-service.yaml
+++ b/kubernetes-ingress/templates/default-backend-service.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}


### PR DESCRIPTION
This is fully backward compatible and make it just more compatible with workflows using `helm template`.

Adding release.Namespace in meta fixes issues when rendering template with 'helm template --namespace'. Without it, the rendered templates do not have the namespace defined which is problematic when using a gitops approach. This is also a requirement for a tool like Spinnaker.

Signed-off-by: lcavajani <lcavajani@suse.com>