### PR TITLE
Allow the use of specific nodePorts

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 0.9.0
+version: 1.0.0
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -88,11 +88,11 @@ spec:
               {{- end }}
           {{- end }}
           {{- range .Values.controller.service.tcpPorts }}
-            - name: {{ . }}-tcp
-              containerPort: {{ . }}
+            - name: {{ .name }}-tcp
+              containerPort: {{ .port }}
               protocol: TCP
               {{- if $useHostPort }}
-              hostPort: {{ . }}
+              hostPort: {{ .port }}
               {{- end }}
           {{- end }}
           livenessProbe:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -74,8 +74,8 @@ spec:
               protocol: TCP
           {{- end }}
           {{- range .Values.controller.service.tcpPorts }}
-            - name: {{ . }}-tcp
-              containerPort: {{ . }}
+            - name: {{ .name }}-tcp
+              containerPort: {{ .port }}
               protocol: TCP
           {{- end }}
           livenessProbe:

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -46,19 +46,31 @@ spec:
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
+  {{- if .Values.controller.service.nodePorts.http }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
+  {{- end }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
+  {{- if .Values.controller.service.nodePorts.https }}
+      nodePort: {{ .Values.controller.service.nodePorts.https }}
+  {{- end }}
     - name: stat
       port: {{ .Values.controller.service.ports.stat }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.stat }}
+  {{- if .Values.controller.service.nodePorts.stat }}
+      nodePort: {{ .Values.controller.service.nodePorts.stat }}
+  {{- end }}
   {{- range .Values.controller.service.tcpPorts }}
-    - name: {{ . }}-tcp
-      port: {{ . }}
+    - name: {{ .name }}-tcp
+      port: {{ .port }}
       protocol: TCP
-      targetPort: {{ . }}
+      targetPort: {{ .targetPort }}
+    {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+    {{- end }}
   {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -143,6 +143,14 @@ controller:
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     healthCheckNodePort: 0
 
+    ## Service nodePorts to use for http, https and stat
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    ## If empty, random ports will be used
+    nodePorts: {}
+    #  http: 31080
+    #  https: 31443
+    #  stat: 31024
+
     ## Service ports to use for http, https and stat
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     ports:
@@ -161,6 +169,10 @@ controller:
     # This is especially useful for TCP services:
     # https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/controller.md
     tcpPorts: []
+    #- name: http-alt
+    #  port: 8080
+    #  targetPort: http-alt
+    #  nodePort: 32080
 
     ## Set external traffic policy
     ## Default is "Cluster", setting it to "Local" preserves source IP


### PR DESCRIPTION
In some setups, external components like a TCP loadbalancer need to know the nodePorts where the controller is exposed.

This commit adds the option to define nodePorts for the default services http, https and stat.

It also adds this option for tcpPorts but **this introduces a breaking change** as a tcpPort must now be a map with name, port, targetPort and optionnaly nodePort.

Signed-off-by: lcavajani <lcavajani@suse.com>