### PR TITLE
Add PSP support and SA for default backend

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 1.0.1
+version: 1.1.0
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/_helpers.tpl
+++ b/kubernetes-ingress/templates/_helpers.tpl
@@ -76,6 +76,17 @@ Create the name of the controller service account to use.
 {{- end -}}
 
 {{/*
+Create the name of the backend service account to use - only used when podsecuritypolicy is also enabled
+*/}}
+{{- define "kubernetes-ingress.defaultBackend.serviceAccountName" -}}
+{{- if or .Values.serviceAccount.create .Values.defaultBackend.serviceAccount.create -}}
+    {{ default (printf "%s-%s" (include "kubernetes-ingress.fullname" .) .Values.defaultBackend.name) .Values.defaultBackend.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.defaultBackend.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified default backend name.
 */}}
 {{- define "kubernetes-ingress.defaultBackend.fullname" -}}

--- a/kubernetes-ingress/templates/clusterrolebinding.yaml
+++ b/kubernetes-ingress/templates/clusterrolebinding.yaml
@@ -15,7 +15,7 @@ limitations under the License.
 */}}
 
 {{- if and .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}

--- a/kubernetes-ingress/templates/controller-podsecuritypolicy.yaml
+++ b/kubernetes-ingress/templates/controller-podsecuritypolicy.yaml
@@ -1,0 +1,72 @@
+{{/*
+Copyright 2019 HAProxy Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled }}
+{{- $useHostPort := .Values.controller.daemonset.useHostPort }}
+{{- $hostPorts := .Values.controller.daemonset.hostPorts -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+{{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+    helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  name: {{ template "kubernetes-ingress.fullname" . }}
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+{{- if $useHostPort }}
+  hostNetwork: true
+  hostPorts:
+{{- range $key, $value := .Values.controller.containerPort }}
+  - min: {{ $value }}
+    max: {{ $value }}
+{{- end }}
+{{- range .Values.controller.service.tcpPorts }}
+  - min: {{ .port }}
+    max: {{ .port }}
+{{- end }}
+{{- end }}
+  hostIPC: false
+  hostPID: false
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - downwardAPI
+  - secret
+{{- end }}

--- a/kubernetes-ingress/templates/controller-role.yaml
+++ b/kubernetes-ingress/templates/controller-role.yaml
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
@@ -26,49 +27,12 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 rules:
-- apiGroups:
-  - ""
+- apiGroups: 
+  - "policy"
   resources:
-  - configmaps
-  - endpoints
-  - nodes
-  - pods
-  - services
-  - namespaces
-  - events
-  - serviceaccounts
+  - podsecuritypolicies
   verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - "extensions"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - "networking.k8s.io/v1beta1"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
+  - use
+  resourceNames:
+  - {{ template "kubernetes-ingress.fullname" . }}
 {{- end -}}

--- a/kubernetes-ingress/templates/controller-rolebinding.yaml
+++ b/kubernetes-ingress/templates/controller-rolebinding.yaml
@@ -14,61 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
   name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - nodes
-  - pods
-  - services
-  - namespaces
-  - events
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - "extensions"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - "networking.k8s.io/v1beta1"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubernetes-ingress.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubernetes-ingress.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -58,6 +58,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      serviceAccountName: {{ template "kubernetes-ingress.defaultBackend.serviceAccountName" . }}
     {{- with .Values.defaultBackend.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/kubernetes-ingress/templates/default-backend-podsecuritypolicy.yaml
+++ b/kubernetes-ingress/templates/default-backend-podsecuritypolicy.yaml
@@ -14,61 +14,46 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
 metadata:
-  name: {{ template "kubernetes-ingress.fullname" . }}
+{{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - nodes
-  - pods
-  - services
-  - namespaces
-  - events
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - "extensions"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - "networking.k8s.io/v1beta1"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-{{- end -}}
+  name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+spec:
+  allowPrivilegeEscalation: false
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  defaultAllowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  privileged: false
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - downwardAPI
+  - secret
+{{- end }}

--- a/kubernetes-ingress/templates/default-backend-role.yaml
+++ b/kubernetes-ingress/templates/default-backend-role.yaml
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: {{ template "kubernetes-ingress.fullname" . }}
+  name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
@@ -26,49 +27,12 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 rules:
-- apiGroups:
-  - ""
+- apiGroups: 
+  - "policy"
   resources:
-  - configmaps
-  - endpoints
-  - nodes
-  - pods
-  - services
-  - namespaces
-  - events
-  - serviceaccounts
+  - podsecuritypolicies
   verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - "extensions"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - "networking.k8s.io/v1beta1"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
+  - use
+  resourceNames:
+  - {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
 {{- end -}}

--- a/kubernetes-ingress/templates/default-backend-rolebinding.yaml
+++ b/kubernetes-ingress/templates/default-backend-rolebinding.yaml
@@ -14,61 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
-  name: {{ template "kubernetes-ingress.fullname" . }}
+  name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - nodes
-  - pods
-  - services
-  - namespaces
-  - events
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - "extensions"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - "networking.k8s.io/v1beta1"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubernetes-ingress.defaultBackend.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/kubernetes-ingress/templates/default-backend-serviceaccount.yaml
+++ b/kubernetes-ingress/templates/default-backend-serviceaccount.yaml
@@ -14,61 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+{{- if and .Values.serviceAccount.create .Values.defaultBackend.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: {{ template "kubernetes-ingress.fullname" . }}
+  name: {{ template "kubernetes-ingress.defaultBackend.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - endpoints
-  - nodes
-  - pods
-  - services
-  - namespaces
-  - events
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - patch
-  - update
-- apiGroups:
-  - "extensions"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - "networking.k8s.io/v1beta1"
-  resources:
-  - ingresses
-  - ingresses/status
-  verbs:
-  - get
-  - list
-  - watch
 {{- end -}}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -15,6 +15,18 @@
 ## Default values for kubernetes-ingress Chart for HAProxy Ingress Controller
 ## ref: https://github.com/haproxytech/kubernetes-ingress/tree/master/documentation
 
+podSecurityPolicy:
+  annotations: {}
+    ## Specify pod annotations
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+    ##
+    # apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    # seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  enabled: false
 
 ## Enable RBAC Authorization
 ## ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
@@ -254,3 +266,8 @@ defaultBackend:
     ## Service ports
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     port: 8080
+
+  ## Configure Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount:
+    create: true


### PR DESCRIPTION
I've tested this on Kubernetes `1.17.4` with upgrading from the previous version (no PSP, no SA for default-backend). When upgrading, with the default values:
*  the `default-backend` pods will be recreated since it is set to use a new `ServiceAccount`. Setting `defaultBackend.defaultBackend.create: false` would disable this by default but I think it's good practice to use a specific `ServiceAccount`.
* PSP are disabled, enabling them is not disruptive

After Enabling PSP, it's required to delete the pods, the pods are correctly using the PSPs

```
$ kubectl -n cluster-addons get po haproxy-kubernetes-ingress-9cv7x -ojson | jq '.metadata.annotations'
{
  "container.apparmor.security.beta.kubernetes.io/kubernetes-ingress-default-backend": "runtime/default",
  "kubernetes.io/psp": "haproxy-kubernetes-ingress-default-backend",
  "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
}

$ kubectl -n cluster-addons get po haproxy-kubernetes-ingress-default-backend-c96fc888c-2ghm5 -ojson | jq '.metadata.annotations'
{
  "container.apparmor.security.beta.kubernetes.io/kubernetes-ingress-default-backend": "runtime/default",
  "kubernetes.io/psp": "haproxy-kubernetes-ingress-default-backend",
  "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
}
```