### PR TITLE
add enablePorts for controller.service to allow better control of which ports are enabled

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 1.1.4
+version: 1.1.5
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -42,26 +42,32 @@ spec:
   healthCheckNodePort: {{ .Values.controller.service.healthCheckNodePort }}
   {{- end }}
   ports:
+  {{- if .Values.controller.service.enablePorts.http }}
     - name: http
       port: {{ .Values.controller.service.ports.http }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.http }}
-  {{- if .Values.controller.service.nodePorts.http }}
+    {{- if .Values.controller.service.nodePorts.http }}
       nodePort: {{ .Values.controller.service.nodePorts.http }}
+    {{- end }}
   {{- end }}
+  {{- if .Values.controller.service.enablePorts.https }}
     - name: https
       port: {{ .Values.controller.service.ports.https }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
-  {{- if .Values.controller.service.nodePorts.https }}
+    {{- if .Values.controller.service.nodePorts.https }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
+    {{- end }}
   {{- end }}
+  {{- if .Values.controller.service.enablePorts.stat }}
     - name: stat
       port: {{ .Values.controller.service.ports.stat }}
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.stat }}
-  {{- if .Values.controller.service.nodePorts.stat }}
+    {{- if .Values.controller.service.nodePorts.stat }}
       nodePort: {{ .Values.controller.service.nodePorts.stat }}
+    {{- end }}
   {{- end }}
   {{- range .Values.controller.service.tcpPorts }}
     - name: {{ .name }}-tcp

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -205,6 +205,14 @@ controller:
       https: 443
       stat: 1024
 
+    ## The controller service ports for http, https and stat can be disabled by
+    ## setting below to false - this could be useful when only deploying haproxy
+    ## as a TCP loadbalancer
+    enablePorts:
+      http: true
+      https: true
+      stat: true
+
     ## Target port mappings for http, https and stat
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     targetPorts:


### PR DESCRIPTION
- leave the default behaviour to have http, https and stat enabled
- add the option to disable http, https and stat
- bump chart version