### PR TITLE
Make replicaCount definition optional

### DIFF
--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -27,7 +27,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  replicas: {{ .Values.controller.replicaCount }}
+  {{- with .Values.controller.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -26,7 +26,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  replicas: {{ .Values.defaultBackend.replicaCount }}
+  {{- with .Values.defaultBackend.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -53,7 +53,7 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
   kind: Deployment    # can be 'Deployment' or 'DaemonSet'
-  replicaCount: 2   # used only for Deployment mode
+  # replicaCount: 2   # used only for Deployment mode. Do not use if also using an HPA
 
   ## Init Containers
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -283,7 +283,7 @@ controller:
 ## Default 404 backend
 defaultBackend:
   name: default-backend
-  replicaCount: 2
+  # replicaCount: 2    # do not use if also using an HPA
 
   image:
     repository: k8s.gcr.io/defaultbackend-amd64


### PR DESCRIPTION
In cases where using a `HorizontalPodAutoscaler` it makes sense to not define `replicas` in a deployment, because the HPA manages the replica count. Otherwise the deployment scales to this value during a `helm upgrade` which can be detrimental if the HPA has already scaled the deployment to a much larger value of replicas.

Some relevant discussion is here: https://github.com/kubernetes/kubernetes/issues/25238 and in particular the issue is described here: https://github.com/kubernetes/kubernetes/issues/25238#issuecomment-406415297

This PR makes the definition of `replicaCount` optional.