### PR TITLE
Make replicaCount definition optional

### DIFF
--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -27,7 +27,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  replicas: {{ .Values.controller.replicaCount }}
+  {{- with .Values.controller.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -26,7 +26,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  replicas: {{ .Values.defaultBackend.replicaCount }}
+  {{- with .Values.defaultBackend.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -53,7 +53,7 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
   kind: Deployment    # can be 'Deployment' or 'DaemonSet'
-  replicaCount: 2   # used only for Deployment mode
+  replicaCount: 2   # used only for Deployment mode. Unset if also using an HPA
 
   ## Init Containers
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -283,7 +283,7 @@ controller:
 ## Default 404 backend
 defaultBackend:
   name: default-backend
-  replicaCount: 2
+  replicaCount: 2    # unset if also using an HPA
 
   image:
     repository: k8s.gcr.io/defaultbackend-amd64


### PR DESCRIPTION
I am opening a new PR, which the changes suggested in #20, because I don't have permissions to re-open #20.

@dkorunic this one keeps the default value for `replicas` but also makes it optional.

Could you have another look?

Thanks!