### PR TITLE
Make replicaCount accept 0 as a valid value

### DIFF
--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -27,8 +27,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  {{- with .Values.controller.replicaCount }}
-  replicas: {{ . }}
+  {{- if not ( kindIs "invalid" .Values.controller.replicaCount) }}
+  replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
   selector:
     matchLabels:

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -26,8 +26,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
-  {{- with .Values.defaultBackend.replicaCount }}
-  replicas: {{ . }}
+  {{- if not (kindIs "invalid" .Values.defaultBackend.replicaCount) }}
+  replicas: {{ .Values.defaultBackend.replicaCount }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
After #21 a value of `0` for `controller.replicaCount` and `defaultBackend.replicaCount` is treated as an empty/null value.

This PR makes `0` treated as a proper value. (Setting `replicaCount` to `0` makes sense in certain cases especially for the default backend)