### PR TITLE
Allow HaProxy to update load balancer status

### DIFF
--- a/kubernetes-ingress/templates/clusterrole.yaml
+++ b/kubernetes-ingress/templates/clusterrole.yaml
@@ -71,4 +71,5 @@ rules:
   - get
   - list
   - watch
+  - update
 {{- end -}}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/19135#issuecomment-576095647

Currently in Rancher using the haproxy ingress results in the ingress status being locked at initializing even though the name resolves perfectly fine.

![image](https://user-images.githubusercontent.com/83597/85738990-5b696580-b6f8-11ea-9cb8-647dd4ea626f.png)

----
haproxy-ingress 1.3.2
[values.txt](https://github.com/haproxytech/helm-charts/files/4831915/values.txt)
from  https://haproxytech.github.io/helm-charts 

