### PR TITLE
Support service's sessionAffinity definition

### DIFF
--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -81,6 +81,9 @@ spec:
   selector:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.controller.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.controller.service.sessionAffinity }}
+  {{- end }}
   externalIPs:
 {{- if .Values.controller.service.externalIPs }}
 {{ toYaml .Values.controller.service.externalIPs | indent 4 }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -267,6 +267,10 @@ controller:
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     # clusterIP: ""
 
+    ## Service session affinity
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    # sessionAffinity: ""
+
   ## Controller DaemonSet configuration
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
   daemonset:


### PR DESCRIPTION
Support changing the service's sessionAffinity setting to something other than the default ("None"), .e.g: to "ClientIP"