### PR TITLE
hostPort without hostNetwork

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -15,6 +15,7 @@ limitations under the License.
 */}}
 
 {{- if eq .Values.controller.kind "DaemonSet" }}
+{{- $useHostNetwork := .Values.controller.daemonset.useHostNetwork -}}
 {{- $useHostPort := .Values.controller.daemonset.useHostPort -}}
 {{- $hostPorts := .Values.controller.daemonset.hostPorts -}}
 apiVersion: apps/v1
@@ -52,7 +53,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "kubernetes-ingress.serviceAccountName" . }}
-      {{- if $useHostPort }}
+      {{- if $useHostNetwork }}
       hostNetwork: true
       {{- end }}
 {{- if .Values.controller.imageCredentials.registry }}

--- a/kubernetes-ingress/templates/controller-podsecuritypolicy.yaml
+++ b/kubernetes-ingress/templates/controller-podsecuritypolicy.yaml
@@ -15,6 +15,7 @@ limitations under the License.
 */}}
 
 {{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled }}
+{{- $useHostNetwork := .Values.controller.daemonset.useHostNetwork }}
 {{- $useHostPort := .Values.controller.daemonset.useHostPort }}
 {{- $hostPorts := .Values.controller.daemonset.hostPorts -}}
 apiVersion: policy/v1beta1
@@ -41,8 +42,10 @@ spec:
     - max: 65535
       min: 1
     rule: MustRunAs
-{{- if $useHostPort }}
+{{- if $useHostNetwork }}
   hostNetwork: true
+{{- end }}
+{{- if or $useHostPort $useHostNetwork }}
   hostPorts:
 {{- range $key, $value := .Values.controller.containerPort }}
   - min: {{ $value }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -274,6 +274,7 @@ controller:
   ## Controller DaemonSet configuration
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
   daemonset:
+    useHostNetwork: false
     useHostPort: false
     hostPorts:
       http: 80


### PR DESCRIPTION
Hello.
This PR adds possibilty to use `hostPort` without having  `hostNetwork: true` in pod. 

**Why this PR?** 
I'm using netwokpolicies on my kubernetes cluster. Network policies don't apply to `hostNetwork: true` pods.
Ingress controller with  `hostNetwork: true` enabled can't access `kind: Ingress` objects of the namespaces with kubernetes `kind: NetworkPolicy` objects enabled (allow rules dont't work for `hostNetwork: true` pods)

Regards