### PR TITLE
MINOR: add env to set timezone

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -132,6 +132,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.controller.env.timezone -}}
+          - name: TZ
+            value: "{{ .Values.controller.env.timezone }}"
+          {{- end -}}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       {{- with.Values.controller.initContainers }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -120,6 +120,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.controller.env.timezone }}
+          - name: TZ
+            value: "{{ .Values.controller.env.timezone }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       {{- with.Values.controller.initContainers }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -289,6 +289,9 @@ controller:
   #    maxUnavailable: 25%
   #  type: RollingUpdate
 
+  env: {}
+    ## Set timezone for controller containers
+    # timezone: "Etc/UTC"
 
 ## Default 404 backend
 defaultBackend:


### PR DESCRIPTION
Add environment variable option to set time zone with `TZ` like [link](https://github.com/haproxytech/kubernetes-ingress/blob/1d44fbb5a5d4c2df566c8aada4f2c25c459e9125/deploy/haproxy-ingress-daemonset.yaml#L162-L164)

```
env:
- name: TZ
  value: "Etc/UTC"
```