### PR TITLE
MINOR: add extraEnvs to set additional envs

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -132,6 +132,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- range .Values.controller.extraEnvs }}
+          - name: "{{ .name }}"
+            value: "{{ .value }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       {{- with.Values.controller.initContainers }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -120,6 +120,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- range .Values.controller.extraEnvs }}
+          - name: {{ .name }}
+            value: {{ .value }}
+          {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
       {{- with.Values.controller.initContainers }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -59,10 +59,10 @@ spec:
               protocol: TCP
           {{- if .Values.defaultBackend.extraEnvs }}
           env:
-          {{- end }}
           {{- range .Values.defaultBackend.extraEnvs }}
           - name: "{{ .name }}"
             value: "{{ .value }}"
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.defaultBackend.resources | nindent 12 }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -54,6 +54,13 @@ spec:
             - name: http
               containerPort: {{ .Values.defaultBackend.containerPort }}
               protocol: TCP
+          {{- if .Values.defaultBackend.extraEnvs }}
+          env:
+          {{- end }}
+          {{- range .Values.defaultBackend.extraEnvs }}
+          - name: "{{ .name }}"
+            value: "{{ .value }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.defaultBackend.resources | nindent 12 }}
       {{- with .Values.defaultBackend.nodeSelector }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -289,6 +289,11 @@ controller:
   #    maxUnavailable: 25%
   #  type: RollingUpdate
 
+  ## Set additional env
+  extraEnvs: []
+    ## Set TZ env to configure timezone on controller containers
+    # - name: TZ
+    #   value: "Etc/UTC"
 
 ## Default 404 backend
 defaultBackend:
@@ -350,3 +355,6 @@ defaultBackend:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccount:
     create: true
+
+  ## Set additional env 
+  extraEnvs: []


### PR DESCRIPTION
Add `.Values.controller.extraEnvs` and `.Values.defaultBackend.extraEnvs` to set additonal environment variables like `TZ` to set time zone [link](https://github.com/haproxytech/kubernetes-ingress/blob/1d44fbb5a5d4c2df566c8aada4f2c25c459e9125/deploy/haproxy-ingress-daemonset.yaml#L162-L164). 
This merge request is better than from my last pull request [#32](https://github.com/haproxytech/helm-charts/pull/32) that was specifically try to add `TZ` environment variable.

  