### PR TITLE
Only create default tls secret when enabled

### DIFF
--- a/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
+++ b/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.controller.defaultTLSSecret.enabled }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -31,3 +32,4 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
 {{ ( include "kubernetes-ingress.gen-certs" . ) | indent 2 }}
+{{- end }}


### PR DESCRIPTION
Creates default TLS secret conditionally via existing `controller.defaultTLSSecret.enabled` flag. Currently this secret is always created resulting in the below changes being reported on every helm diff as the cert is regenerated:

```
  data:
-   tls.crt: '-------- # (1127 bytes)'
-   tls.key: '-------- # (1671 bytes)'
+   tls.crt: '++++++++ # (1172 bytes)'
+   tls.key: '++++++++ # (1679 bytes)'
  type: kubernetes.io/tls
```