### PR TITLE
Adding support for Prometheus ServiceMonitor

### DIFF
--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -123,6 +123,15 @@ helm install my-ingress4 haproxytech/kubernetes-ingress \
   --set defaultBackend.replicaCount=null
 ```
 
+### Installing the ServiceMonitor
+
+If you're using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), you can automatically install the `ServiceMonitor` definition in order to automate the scraping options according to your needs.
+
+```console
+helm install my-ingress5 haproxytech/kubernetes-ingress \
+  --set "serviceMonitor.enabled=true"
+```
+
 ### Using values from YAML file
 
 As opposed to using many `--set` invocations, much simpler approach is to define value overrides in a separate YAML file and specify them when invoking Helm:

--- a/kubernetes-ingress/templates/_helpers.tpl
+++ b/kubernetes-ingress/templates/_helpers.tpl
@@ -120,4 +120,11 @@ Construct the syslog-server annotation
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified ServiceMonitor name.
+*/}}
+{{- define "kubernetes-ingress.serviceMonitorName" -}}
+{{- default (include "kubernetes-ingress.fullname" .) .Values.controller.serviceMonitor.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/* vim: set filetype=mustache: */}}

--- a/kubernetes-ingress/templates/controller-servicemonitor.yaml
+++ b/kubernetes-ingress/templates/controller-servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{/*
+Copyright 2019 HAProxy Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.controller.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kubernetes-ingress.serviceMonitorName" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+    helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- if .Values.controller.serviceMonitor.extraLabels }}
+    {{ toYaml .Values.controller.serviceMonitor.extraLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    {{ .Values.controller.serviceMonitor.endpoints | toYaml | nindent 4 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -367,6 +367,19 @@ controller:
     #   configMap:
     #     name: sidecar-config
 
+  ## ServiceMonitor
+  ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/getting-started.md
+  serviceMonitor:
+    ## Toggle the ServiceMonitor, true if you have Prometheus Operator installed and configured
+    enabled: false
+    ## Specify the labels to add to the ServiceMonitors to be selected for target discovery
+    extraLabels: {}
+    ## Specify the endpoints
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#servicemonitor
+    endpoints:
+    - port: stat
+      path: /metrics
+      scheme: http
 
 ## Default 404 backend
 defaultBackend:


### PR DESCRIPTION
Since HAProxy is already serving Prometheus metrics on 1024 port, would be great having also the `ServiceMonitor` template in order to automate scraping using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) stack.

Default value is set to `false` in order to don't introduce breaking change due to non installed CRDs.

> Actually, scraping can be easily achieved using basic Prometheus installation and its Kubernetes service discovery capabilities thanks to the annotation `prometheus.io/scrape` but this is not powerful since it allows just defining the toggling, port, and path.