### PR TITLE
FEATURE/MINOR: allow disabling default backend

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -85,7 +85,9 @@ spec:
 {{- end }}
 {{- end }}
           - --configmap={{ .Release.Namespace }}/{{ template "kubernetes-ingress.fullname" . }}
+{{- if .Values.defaultBackend.enabled }}
           - --default-backend-service={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+{{- end }}
 {{- if .Values.controller.ingressClass }}
           - --ingress.class={{ .Values.controller.ingressClass }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -79,7 +79,9 @@ spec:
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
 {{- end }}
           - --configmap={{ .Release.Namespace }}/{{ template "kubernetes-ingress.fullname" . }}
+{{- if .Values.defaultBackend.enabled }}
           - --default-backend-service={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultBackend.fullname" . }}
+{{- end }}
 {{- if .Values.controller.ingressClass }}
           - --ingress.class={{ .Values.controller.ingressClass }}
 {{- end }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.defaultBackend.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,3 +81,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- end }}

--- a/kubernetes-ingress/templates/default-backend-hpa.yaml
+++ b/kubernetes-ingress/templates/default-backend-hpa.yaml
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Values.defaultBackend.autoscaling.enabled }}
+{{- if and .Values.defaultBackend.autoscaling.enabled .Values.defaultBackend.enabled }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/kubernetes-ingress/templates/default-backend-podsecuritypolicy.yaml
+++ b/kubernetes-ingress/templates/default-backend-podsecuritypolicy.yaml
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled }}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/kubernetes-ingress/templates/default-backend-role.yaml
+++ b/kubernetes-ingress/templates/default-backend-role.yaml
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/kubernetes-ingress/templates/default-backend-rolebinding.yaml
+++ b/kubernetes-ingress/templates/default-backend-rolebinding.yaml
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled .Values.defaultBackend.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/kubernetes-ingress/templates/default-backend-service.yaml
+++ b/kubernetes-ingress/templates/default-backend-service.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.defaultBackend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,7 +28,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 spec:
   type: ClusterIP
-  clusterIP: None 
+  clusterIP: None
   ports:
     - name: http
       port: {{ .Values.defaultBackend.service.port }}
@@ -36,3 +37,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.defaultBackend.fullname" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/kubernetes-ingress/templates/default-backend-serviceaccount.yaml
+++ b/kubernetes-ingress/templates/default-backend-serviceaccount.yaml
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and .Values.serviceAccount.create .Values.defaultBackend.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create .Values.defaultBackend.serviceAccount.create .Values.defaultBackend.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -385,6 +385,7 @@ controller:
 
 ## Default 404 backend
 defaultBackend:
+  enabled: true
   name: default-backend
   replicaCount: 2
 


### PR DESCRIPTION
This PR adds support for disabling default backend resources via `defaultBackend.enabled` flag.

When this flag is set to `false`, default backend won't be deployed and as a result HAProxy will use `503` error code in response to unknown vhosts, which itself may be required in some web hosting scenarios (like preventing search engines from un-listing pages).