### PR TITLE
allow for haproxy (sidecar?) to use an existing imagePullSecret

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -72,8 +72,7 @@ helm install my-haproxy haproxytech/haproxy  \
   --set imageCredentials.password=MYPASSWORD
 ```
 
-Alternatively, use a pre-configured (existing) imagePullSecret in the same namespace
-
+Alternatively, use a pre-configured (existing) imagePullSecret in the same namespace:
 
 ```console
 helm install my-ingress haproxytech/haproxy  \
@@ -81,7 +80,6 @@ helm install my-ingress haproxytech/haproxy  \
   --set image.tag=SOMETAG \
   --set existingImagePullSecret name-of-existing-image-pull-secret
 ```
-
 
 ### Installing as DaemonSet
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -79,7 +79,7 @@ Alternatively, use a pre-configured (existing) imagePullSecret in the same names
 helm install my-ingress haproxytech/haproxy  \
   --namespace prod \
   --set image.tag=SOMETAG \
-  --set eexistingImagePullSecret name-of-existing-image-pull-secret
+  --set existingImagePullSecret name-of-existing-image-pull-secret
 ```
 
 

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -72,6 +72,17 @@ helm install my-haproxy haproxytech/haproxy  \
   --set imageCredentials.password=MYPASSWORD
 ```
 
+Alternatively, use a pre-configured (existing) imagePullSecret in the same namespace
+
+
+```console
+helm install my-ingress haproxytech/haproxy  \
+  --namespace prod \
+  --set image.tag=SOMETAG \
+  --set eexistingImagePullSecret name-of-existing-image-pull-secret
+```
+
+
 ### Installing as DaemonSet
 
 Default image mode is [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/), but it is possible to use [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) as well:

--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -61,6 +61,9 @@ spec:
 {{- if .Values.imageCredentials.registry }}
       imagePullSecrets:
       - name: {{ include "haproxy.fullname" . }}
+{{- else if .Values.existingImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.existingImagePullSecret }}
 {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
 {{- if .Values.imageCredentials.registry }}
       imagePullSecrets:
       - name: {{ include "haproxy.fullname" . }}
+{{- else if .Values.existingImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.existingImagePullSecret }}
 {{- end }}
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -64,6 +64,7 @@ imageCredentials:
   registry: null    ## EE images require setting this
   username: null    ## EE images require setting this
   password: null    ## EE images require setting this
+existingImagePullSecret: null
 
 ## Container listener port configuration
 ## ref: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/

--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -77,6 +77,16 @@ helm install my-ingress haproxytech/kubernetes-ingress  \
   --set controller.imageCredentials.password=MYPASSWORD
 ```
 
+Alternatively, use a pre-configured (existing) imagePullSecret in the same namespace
+
+
+```console
+helm install my-ingress haproxytech/kubernetes-ingress  \
+  --namespace prod \
+  --set controller.image.tag=SOMETAG \
+  --set controller.eexistingImagePullSecret name-of-existing-image-pull-secret
+```
+
 ### Installing as DaemonSet
 
 Default controller mode is [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/), but it is possible to use [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) as well:

--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -77,8 +77,7 @@ helm install my-ingress haproxytech/kubernetes-ingress  \
   --set controller.imageCredentials.password=MYPASSWORD
 ```
 
-Alternatively, use a pre-configured (existing) imagePullSecret in the same namespace
-
+Alternatively, use a pre-configured (existing) imagePullSecret in the same namespace:
 
 ```console
 helm install my-ingress haproxytech/kubernetes-ingress  \

--- a/kubernetes-ingress/README.md
+++ b/kubernetes-ingress/README.md
@@ -84,7 +84,7 @@ Alternatively, use a pre-configured (existing) imagePullSecret in the same names
 helm install my-ingress haproxytech/kubernetes-ingress  \
   --namespace prod \
   --set controller.image.tag=SOMETAG \
-  --set controller.eexistingImagePullSecret name-of-existing-image-pull-secret
+  --set controller.existingImagePullSecret name-of-existing-image-pull-secret
 ```
 
 ### Installing as DaemonSet

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -68,6 +68,9 @@ spec:
 {{- if .Values.controller.imageCredentials.registry }}
       imagePullSecrets:
       - name: {{ template "kubernetes-ingress.fullname" . }}
+{{- else if .Values.controller.existingImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.controller.existingImagePullSecret }}
 {{- end }}
 {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -64,6 +64,9 @@ spec:
 {{- if .Values.controller.imageCredentials.registry }}
       imagePullSecrets:
       - name: {{ template "kubernetes-ingress.fullname" . }}
+{{- else if .Values.controller.existingImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.controller.existingImagePullSecret }}
 {{- end }}
 {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -81,6 +81,7 @@ controller:
     registry: null
     username: null
     password: null
+  existingImagePullSecret: null
 
   ## Controller Container listener port configuration
   ## ref: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/


### PR DESCRIPTION
We recently have a requirement to use a sidecar with haproxy but noticed there is no way to use an existing imagePullSecret which we already have within the same namespace as haproxy - this is a simple workaround for that situation.