### PR TITLE
Feature: pod disruption budget

### DIFF
--- a/haproxy/templates/poddisruptionbudget.yaml
+++ b/haproxy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,34 @@
+{{/*
+Copyright 2019 HAProxy Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.PodDisruptionBudget.enable }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "haproxy.fullname" . }}
+  labels:
+    {{- include "haproxy.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.PodDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.PodDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.PodDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+    {{- include "haproxy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -172,6 +172,13 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+## Pod Disruption Budget
+## Only to be used with Deployment kind
+PodDisruptionBudget:
+  enable: true
+  maxUnavailable: 1
+  # minAvailable: 1
+
 ## Service configuration
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/kubernetes-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/kubernetes-ingress/templates/controller-poddisruptionbudget.yaml
@@ -1,0 +1,40 @@
+{{/*
+Copyright 2019 HAProxy Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.controller.PodDisruptionBudget.enable }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "kubernetes-ingress.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+    helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  {{- if .Values.controller.PodDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.controller.PodDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.controller.PodDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.controller.PodDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -169,6 +169,13 @@ controller:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+  ## Pod Disruption Budget
+  ## Only to be used with Deployment kind
+  PodDisruptionBudget:
+    enable: true
+    # maxUnavailable: 1
+    # minAvailable: 1
+
   ## Pod Node assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   nodeSelector: {}


### PR DESCRIPTION
Adding support of `PodDisruptionBudget` for bot haproxy and kubernetes-ingress helm charts to reduce downtime in production