### PR TITLE
MINOR: Add reference link + disable PDB default

### DIFF
--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -174,9 +174,10 @@ autoscaling:
 
 ## Pod Disruption Budget
 ## Only to be used with Deployment kind
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 PodDisruptionBudget:
-  enable: true
-  maxUnavailable: 1
+  enable: false
+  # maxUnavailable: 1
   # minAvailable: 1
 
 ## Service configuration

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -171,8 +171,9 @@ controller:
 
   ## Pod Disruption Budget
   ## Only to be used with Deployment kind
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   PodDisruptionBudget:
-    enable: true
+    enable: false
     # maxUnavailable: 1
     # minAvailable: 1
 


### PR DESCRIPTION
I add a reference link for PDB objects in `values.yaml` and make PDB disable by default