### PR TITLE
ability to disable PodSecurityPolicy

### DIFF
--- a/haproxy/templates/podsecuritypolicy.yaml
+++ b/haproxy/templates/podsecuritypolicy.yaml
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.podSecurityPolicy.create -}}
+
 {{- $useHostNetwork := .Values.daemonset.useHostNetwork -}}
 {{- $useHostPort := .Values.daemonset.useHostPort -}}
 {{- $hostPorts := .Values.daemonset.hostPorts -}}
@@ -64,3 +66,5 @@ spec:
     - emptyDir
     - projected
     - secret
+
+{{- end }}

--- a/haproxy/templates/podsecuritypolicy.yaml
+++ b/haproxy/templates/podsecuritypolicy.yaml
@@ -15,7 +15,6 @@ limitations under the License.
 */}}
 
 {{- if .Values.podSecurityPolicy.create -}}
-
 {{- $useHostNetwork := .Values.daemonset.useHostNetwork -}}
 {{- $useHostPort := .Values.daemonset.useHostPort -}}
 {{- $hostPorts := .Values.daemonset.hostPorts -}}
@@ -66,5 +65,4 @@ spec:
     - emptyDir
     - projected
     - secret
-
 {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -141,6 +141,11 @@ podAnnotations: {}
 #  key: value
 #
 
+## Disableable use of Pod Security Policy
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy: 
+  create: true
+
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 podSecurityContext: {}


### PR DESCRIPTION
PodSecurityPolicy is a cluster-level resource. It is not needed in every deploy, so there should be an option to disable it.

Signed-off-by: Andrey Regentov <a.regentov@ftc.ru>