### PR TITLE
Fixed indentation in default values.yaml for resources.requests property

### DIFF
--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -163,9 +163,9 @@ resources:
 #  limits:
 #    cpu: 100m
 #    memory: 64Mi
-requests:
-  cpu: 100m
-  memory: 64Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi
 
 ## Horizontal Pod Scaler
 ## Only to be used with Deployment kind


### PR DESCRIPTION
We missed indentation in default values which made the whole property `requests` to be ignored.