### PR TITLE
Allow setting pod topologySpreadConstraints

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 1.12.4
+version: 1.12.5
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -56,6 +56,10 @@ spec:
     spec:
       serviceAccountName: {{ template "kubernetes-ingress.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
+{{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- if .Values.controller.dnsConfig }}
       dnsConfig:
 {{ toYaml .Values.controller.dnsConfig | indent 8 }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -47,6 +47,10 @@ spec:
 {{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+{{- with .Values.defaultBackend.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}
 {{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -201,7 +201,8 @@ controller:
   #   whenUnsatisfiable: DoNotSchedule
   #   labelSelector:
   #     matchLabels:
-  #       app: foo
+  #       app.kubernetes.io/name: kubernetes-ingress
+  #       app.kubernetes.io/instance: kubernetes-ingress
 
   ## Pod DNS Config
   ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
@@ -475,7 +476,8 @@ defaultBackend:
   #   whenUnsatisfiable: DoNotSchedule
   #   labelSelector:
   #     matchLabels:
-  #       app: foo
+  #       app.kubernetes.io/name: kubernetes-ingress-kubernetes-ingress-default-backend
+  #       app.kubernetes.io/instance: haproxy-ingress
 
   ## Additional labels to add to the pod container metadata
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -193,6 +193,16 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
+  ## Topology spread constraints (only used in kind: Deployment)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app: foo
+
   ## Pod DNS Config
   ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
   dnsConfig: {}
@@ -456,6 +466,16 @@ defaultBackend:
   ## Node Affinity for pod-node scheduling constraints
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+
+  ## Topology spread constraints
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/zone
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app: foo
 
   ## Additional labels to add to the pod container metadata
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
Hi,

this PR`s changes allow setting up topologySpreadConstraints for defaultBackend and/or controller pods.

This is also requested as enhancement here https://github.com/haproxytech/helm-charts/issues/60