### PR TITLE
Added customizing default TLS secret namespace

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -81,8 +81,8 @@ spec:
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
 {{- if and .Values.controller.defaultTLSSecret.enabled -}}
-{{- if .Values.controller.defaultTLSSecret.secret }}
-          - --default-ssl-certificate={{ .Release.Namespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
+{{- if and .Values.controller.defaultTLSSecret.secret .Values.controller.defaultTLSSecret.secretNamespace }}
+          - --default-ssl-certificate={{ .Values.controller.defaultTLSSecret.secretNamespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
 {{- else }}
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -80,10 +80,12 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ tpl .Values.controller.image.tag . }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
+{{- if and .Values.controller.defaultTLSSecret.enabled -}}
 {{- if and .Values.controller.defaultTLSSecret.secret .Values.controller.defaultTLSSecret.secretNamespace }}
           - --default-ssl-certificate={{ .Values.controller.defaultTLSSecret.secretNamespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
 {{- else }}
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
+{{- end }}
 {{- end }}
           - --configmap={{ .Release.Namespace }}/{{ template "kubernetes-ingress.fullname" . }}
 {{- if .Values.defaultBackend.enabled }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -80,7 +80,7 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ tpl .Values.controller.image.tag . }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
-{{- if .Values.controller.defaultTLSSecret.secret }}
+{{- if and .Values.controller.defaultTLSSecret.secret .Values.controller.defaultTLSSecret.secretNamespace }}
           - --default-ssl-certificate={{ .Values.controller.defaultTLSSecret.secretNamespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
 {{- else }}
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -81,7 +81,7 @@ spec:
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
 {{- if .Values.controller.defaultTLSSecret.secret }}
-          - --default-ssl-certificate={{ .Release.Namespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
+          - --default-ssl-certificate={{ .Values.controller.defaultTLSSecret.secretNamespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
 {{- else }}
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
 {{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -147,6 +147,7 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/configuration/secret/
   defaultTLSSecret:
     enabled: true
+    secretNamespace: "{{ .Release.Namespace }}"
     secret: null
 
   ## Compute Resources for controller container


### PR DESCRIPTION
Allows the customization of the namespace for the default TLS secret instead of hard coding the namespace to the release namespace.

The default value in Values.yaml is set to the release namespace, as this is the most likely location for the secret. 

For these two files, note the changes on line 34.

Output for `helm template --debug .`:
[default-values-controller-deployment.txt](https://github.com/haproxytech/helm-charts/files/6351256/default-values-controller-deployment.txt)

Output for `helm template --debug . --set controller.defaultTLSSecret.secretNamespace=test-ns`:
[custom-namespace-controller-deployment.txt](https://github.com/haproxytech/helm-charts/files/6351255/custom-namespace-controller-deployment.txt)

Related: /haproxytech/kubernetes-ingress/issues/300
