### PR TITLE
Support auto-scaling based on custom metrics

### DIFF
--- a/kubernetes-ingress/templates/controller-hpa.yaml
+++ b/kubernetes-ingress/templates/controller-hpa.yaml
@@ -46,4 +46,7 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.controller.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+  {{- if .Values.controller.autoscaling.custom }}
+  {{- toYaml .Values.controller.autoscaling.custom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/kubernetes-ingress/templates/default-backend-hpa.yaml
+++ b/kubernetes-ingress/templates/default-backend-hpa.yaml
@@ -46,4 +46,7 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.defaultBackend.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+  {{- if .Values.defaultBackend.autoscaling.custom }}
+  {{- toYaml .Values.defaultBackend.autoscaling.custom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -173,6 +173,14 @@ controller:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+    ## Custom metrics (example)
+    ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
+    # custom:
+    #   - type: Pods
+    #     pods:
+    #       metricName: haproxy_backend_current_sessions
+    #       targetAverageValue: 2000
+
   ## Pod Disruption Budget
   ## Only to be used with Deployment kind
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
@@ -451,6 +459,14 @@ defaultBackend:
     maxReplicas: 2
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+
+    ## Custom metrics (example)
+    ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics
+    # custom:
+    #   - type: Pods
+    #     pods:
+    #       metricName: haproxy_backend_current_sessions
+    #       targetAverageValue: 2000
 
   ## Listener port configuration
   ## ref: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/


### PR DESCRIPTION
It would be useful if the HPA created by the kubernetes-ingress Helm chart, could be configured to scale the number of HAProxy pods based on custom metrics other than CPU and memory utilization.

For example, auto-scale based on the number of backend connections or number of requests/second.

This is something that we have been doing for some time now by using a custom HPA definition outside of the Helm chart and would love to see it supported by the official chart.

It requires the use of something like https://github.com/kubernetes-sigs/prometheus-adapter

References:
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics