### PR TITLE
FEATURE/MINOR: haproxy: Support mounted secrets

### DIFF
--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
         - name: haproxy-config
           configMap:
             name: {{ include "haproxy.fullname" . }}
+        {{- range $mountedSecret := .Values.mountedSecrets }}
+        - name: {{ $mountedSecret.volumeName }}
+          secret:
+            secretName: {{ $mountedSecret.secretName }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext.enabled }}
@@ -96,6 +101,10 @@ spec:
           volumeMounts:
             - name: haproxy-config
               mountPath: /usr/local/etc/haproxy
+            {{- range $mountedSecret := .Values.mountedSecrets }}
+            - name: {{ $mountedSecret.volumeName }}
+              mountPath: {{ $mountedSecret.mountPath }}
+            {{- end }}
       {{- with.Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -105,6 +105,13 @@ config: |
   backend be_main
     server web1 10.0.0.1:8080 check
 
+## Additional secrets to mount as volumes
+## This is expected to be an array of dictionaries specifying the volume name, secret name and mount path
+mountedSecrets: []
+#  - volumeName: ssl-certificate
+#    secretName: star-example-com
+#    mountPath: /usr/local/etc/ssl
+
 ## Pod Node assignment
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}


### PR DESCRIPTION
With this change it is possible to e.g. support adding certificates to HAProxy from Kubernetes secrets by mounting them into volumes. The configuration is intentionally kept very flexible.

This effectively solves the same problem as https://github.com/haproxytech/helm-charts/pull/46, which currently is in a conflicted state, but with another approach of managing the volumes.