### PR TITLE
Allow valueFrom usage with controller.extraEnvs

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -175,9 +175,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          {{- range .Values.controller.extraEnvs }}
-          - name: "{{ .name }}"
-            value: "{{ .value }}"
+          {{- if .Values.controller.extraEnvs -}}
+            {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -178,9 +178,16 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          {{- range .Values.controller.extraEnvs }}
-          - name: {{ .name }}
-            value: {{ .value }}
+          {{- if .Values.controller.extraEnvs -}}
+          {{- toYaml .Values.controller.extraEnvs | nindent 10 }}
+{{/*      {{- range .Values.controller.extraEnvs }}*/}}
+{{/*      - name: {{ .name }}*/}}
+{{/*        {{- if hasKey . "value" }}*/}}
+{{/*        value: {{ .value }}*/}}
+{{/*        {{- else if hasKey . "valueFrom" }}*/}}
+{{/*        valueFrom: {{- toYaml .valueFrom | nindent 14 }}*/}}
+{{/*        {{- end }}*/}}
+{{/*      {{- end }}*/}}
           {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -179,15 +179,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           {{- if .Values.controller.extraEnvs -}}
-          {{- toYaml .Values.controller.extraEnvs | nindent 10 }}
-{{/*      {{- range .Values.controller.extraEnvs }}*/}}
-{{/*      - name: {{ .name }}*/}}
-{{/*        {{- if hasKey . "value" }}*/}}
-{{/*        value: {{ .value }}*/}}
-{{/*        {{- else if hasKey . "valueFrom" }}*/}}
-{{/*        valueFrom: {{- toYaml .valueFrom | nindent 14 }}*/}}
-{{/*        {{- end }}*/}}
-{{/*      {{- end }}*/}}
+            {{- toYaml .Values.controller.extraEnvs | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/kubernetes-ingress/templates/default-backend-deployment.yaml
+++ b/kubernetes-ingress/templates/default-backend-deployment.yaml
@@ -64,10 +64,7 @@ spec:
               protocol: TCP
           {{- if .Values.defaultBackend.extraEnvs }}
           env:
-          {{- range .Values.defaultBackend.extraEnvs }}
-          - name: "{{ .name }}"
-            value: "{{ .value }}"
-          {{- end }}
+            {{- toYaml .Values.defaultBackend.extraEnvs | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.defaultBackend.resources | nindent 12 }}


### PR DESCRIPTION
## Description

Currently, `kubernetes-ingress.controller.extraEnvs` only accepts key-value transparent values.

However Kubernetes supports [using Secrets for environment variables](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).

This PR allows chart users to define such environment values for the controller deployment, e.g.:
```yaml
# values.yaml
kubernetes-ingress:
    controller:
      extraEnvs:
        - name: TEST_STR
          value: foo
        - name: TEST_MAP
          valueFrom:
            secretKeyRef:
              name: github
              key: clientSecret
```
As you can see this change is backwards compatible with current behavior.

I left a comment in the implementation - not sure which approach you guys will prefer @Mo3m3n @dkorunic but please LMK!