### PR TITLE
New Helm chart features

### DIFF
--- a/haproxy/templates/configmap.yaml
+++ b/haproxy/templates/configmap.yaml
@@ -23,5 +23,5 @@ metadata:
   {{- include "haproxy.labels" . | nindent 4 }}
 data:
   haproxy.cfg: |
-  {{ .Values.config | nindent 4 }}
+  {{ tpl .Values.config . | nindent 4 }}
 {{- end }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -39,9 +39,9 @@ spec:
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}
-      {{- if .Values.podAnnotations }}
       annotations:
         checksum/environment: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
@@ -73,6 +73,9 @@ spec:
           secret:
             secretName: {{ $mountedSecret.secretName }}
         {{- end }}
+        {{- with.Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext.enabled }}
@@ -101,6 +104,9 @@ spec:
           volumeMounts:
             - name: haproxy-config
               mountPath: /usr/local/etc/haproxy
+            {{- with.Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- range $mountedSecret := .Values.mountedSecrets }}
             - name: {{ $mountedSecret.volumeName }}
               mountPath: {{ $mountedSecret.mountPath }}


### PR DESCRIPTION
- Always inject default pod annotation (that includes the hash of configmap)
- allow templates in configmap
- allow extraVolumes and VolumeMounts

I can split this up into 3 PRs if needed.

The rationale behind templating is that in our case, most of our hostnames are dynamic, so for our haproxy.cfg we'd need to do things like `server {{ .Release.Name }}-backend` which wasn't possible before.

We could get around this by manually creating our own `configmap` and using `config: null` in the values, however you lose out on some nice features like the `checksum/environment` annotation (which I changed to be included by default) as well as any future changes to the base configmap template.

The last extraVolumes and extraVolumeMounts fixes https://github.com/haproxytech/helm-charts/issues/75