### PR TITLE
BUG/MINOR: kubernetes-ingress: Fixes typo in template evaluation of .Values.controller.defaultTLSSecret.secretNamespace

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kubernetes-ingress
-version: 1.15.3
+version: 1.15.4
 kubeVersion: ">=1.12.0-0"
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 keywords:

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -82,7 +82,7 @@ spec:
           args:
 {{- if .Values.controller.defaultTLSSecret.enabled -}}
 {{- if and .Values.controller.defaultTLSSecret.secret .Values.controller.defaultTLSSecret.secretNamespace }}
-          - --default-ssl-certificate={{ tpl .Values.controller.defaultTLSSecret.secretNamespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
+          - --default-ssl-certificate={{ tpl .Values.controller.defaultTLSSecret.secretNamespace . }}/{{ .Values.controller.defaultTLSSecret.secret }}
 {{- else }}
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           args:
 {{- if .Values.controller.defaultTLSSecret.enabled -}}
 {{- if and .Values.controller.defaultTLSSecret.secret .Values.controller.defaultTLSSecret.secretNamespace }}
-          - --default-ssl-certificate={{ tpl .Values.controller.defaultTLSSecret.secretNamespace }}/{{ .Values.controller.defaultTLSSecret.secret }}
+          - --default-ssl-certificate={{ tpl .Values.controller.defaultTLSSecret.secretNamespace . }}/{{ .Values.controller.defaultTLSSecret.secret }}
 {{- else }}
           - --default-ssl-certificate={{ .Release.Namespace }}/{{ template "kubernetes-ingress.defaultTLSSecret.fullname" . }}
 {{- end }}


### PR DESCRIPTION

Tag release 1.15.4.