### PR TITLE
Expose configuration for annotations of the default backend service

### DIFF
--- a/kubernetes-ingress/templates/default-backend-service.yaml
+++ b/kubernetes-ingress/templates/default-backend-service.yaml
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
 {{- if .Values.defaultBackend.service.annotations }}
-      annotations:
+  annotations:
 {{ toYaml .Values.defaultBackend.service.annotations | indent 8 }}
 {{- end }}
 spec:

--- a/kubernetes-ingress/templates/default-backend-service.yaml
+++ b/kubernetes-ingress/templates/default-backend-service.yaml
@@ -26,6 +26,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- if .Values.defaultBackend.service.annotations }}
+      annotations:
+{{ toYaml .Values.defaultBackend.service.annotations | indent 8 }}
+{{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -510,6 +510,8 @@ defaultBackend:
   #  key: value
 
   service:
+    ## Annotations for the default backend service object. 
+    annotations: {}
     ## Service ports
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     port: 8080

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -512,6 +512,9 @@ defaultBackend:
   service:
     ## Annotations for the default backend service object. 
     annotations: {}
+    # Use the controller as default backend
+    # haproxy.org/backend-config-snippet: http-request return status 404
+    
     ## Service ports
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     port: 8080


### PR DESCRIPTION
I'm not really a fan of running a dedicated default backend. Therefore I scaled it to "0" and just set an annotation on the default backend service object. This can certainly be useful for other cases, too.

The idea is not new: https://github.com/haproxytech/kubernetes-ingress/issues/71