### PR TITLE
Add externalTrafficPolicy option to haproxy service

### DIFF
--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -28,6 +28,9 @@ spec:
   type: {{ .Values.service.type }}
   selector:
     {{- include "haproxy.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   {{- with .Values.service.clusterIP }}
   clusterIP: {{ . | quote}}
   {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -231,3 +231,7 @@ service:
   ## Service annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   annotations: {}
+
+  ## Service externalTrafficPolicy
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
+  # externalTrafficPolicy: Cluster


### PR DESCRIPTION
This pull request adds the ability to control the `externalTrafficPolicy` option on the Service object.

This is necessary to be able to get real source IPs in most Kubernetes environments.