### PR TITLE
sync daemonset to deployment

### DIFF
--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -115,6 +115,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.lifecycle }}
           lifecycle:
             {{- if eq "string" (printf "%T" .Values.lifecycle) }}
 {{ tpl .Values.lifecycle . | indent 12 }}
@@ -122,7 +123,6 @@ spec:
 {{ toYaml .Values.lifecycle | indent 12 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.extraVolumeMounts }}
           volumeMounts:
             - name: haproxy-config
               mountPath: /usr/local/etc/haproxy


### PR DESCRIPTION
when i was trying to use this helmchart, i tried to use the example provided in the readme:

```
service:
  type: LoadBalancer
config: |
  global
    log stdout format raw local0
    daemon
    maxconn 1024
  defaults
    log global
    timeout client 60s
    timeout connect 60s
    timeout server 60s
  frontend fe_main
    mode http
    bind :80
    bind :443 ssl crt /usr/local/etc/ssl/tls.crt
    http-request redirect scheme https code 301 unless { ssl_fc }
    default_backend be_main
  backend be_main
    mode http
    server web1 10.0.0.1:8080 check
mountedSecrets:
  - volumeName: ssl-certificate
    secretName: star-example-com
    mountPath: /usr/local/etc/ssl
```

this does currently only seem to work when useing a daemonset:
```
Kind: daemonset
```
this seem to be because the volumemount is not added when there are no extraVolumeMounts

i think this is unwanted behavior, so i synced code from daemonset.yaml to deployment.yaml

thanks for helping!