### PR TITLE
FEATURE/MEDIUM: Configure spec.controller field of IngressClass

### DIFF
--- a/kubernetes-ingress/templates/controller-ingressclass.yaml
+++ b/kubernetes-ingress/templates/controller-ingressclass.yaml
@@ -14,15 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.ingressClassResource.enabled) (.Values.controller.ingressClass) -}}
-{{- if and (semverCompare "=1.18-0" .Capabilities.KubeVersion.GitVersion)  }}
+{{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) (.Values.controller.ingressClassResource.name) -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: IngressClass
 metadata:
-  name: {{ .Values.controller.ingressClass }}
+  name: {{ .Values.controller.ingressClassResource.name }}
   labels:
     app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
     helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
@@ -34,9 +33,12 @@ metadata:
     ingressclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 spec:
+{{- if not .Values.controller.ingressClass }}
   controller: haproxy.org/ingress-controller
+{{- else }}
+  controller: haproxy.org/ingress-controller/{{ .Values.controller.ingressClass }}
+{{- end }}
   {{- if .Values.controller.ingressClassResource.parameters }}
   parameters:
 {{ toYaml .Values.controller.ingressClassResource.parameters | indent 4 }}
-  {{- end }}
 {{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -125,18 +125,22 @@ controller:
     successThreshold: 1
     timeoutSeconds: 1
 
-  ## Ingress Class used for ingress.class annotation in multi-ingress environments
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#using-multiple-ingress-controllers
-  ingressClass: haproxy   # typically "haproxy" or null to receive all events
+  ## IngressClass:
+  ## Ref: https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/ingressclass.md
 
-  ## Ingress Class resource with additional configuration and name of the controller
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
-  ## Note: Uses ingressClass as name for the Ingress Class object if enabled
+  # k8s >= 1.18: IngressClass resource used, in multi-ingress environments, to select ingress resources to implement.
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
+  # Note: Uses ingressClass as name for the Ingress Class object if enabled
   ingressClassResource:
-    enabled: false
+    name: haproxy
     default: false
     parameters: {}
+
+  # k8s < 1.18: Ingress Class used, in multi-ingress environments, for ingress.class annotation to select ingress resources to implement.
+  # k8s >= 1.18: Ingress Class used to target specific HAProxy Ingress Controller in multi-ingress envionments
+  # ref: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#using-multiple-ingress-controllers
+  ingressClass: haproxy   # typically "haproxy" or null to receive all events
 
   ## Additional labels to add to the deployment or daemonset metadata
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
spec.controller field of IngressClass resource can now be configured by
appending the value of `--ingress.class` controller's argument.
This is useful when using multiple HAProy Ingress Controller instances
at the same time.
The spec.controller fix is available from 1.7.2

This patch introduces the following breaking changes:
1. Updating controller.ingressClass value makes Helm update
   spec.controller field of the ingressClass resource. Note that this
   field is immutable so helm upgrades with modified
   controller.ingressClass value are going to fail.
2. controller.ingressClassResoruce.enabled was replaced by
   controller.ingressClassResoruce.name