### PR TITLE
AWS MarketPlace bug fixes

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -197,11 +197,16 @@ spec:
 {{ toYaml .Values.controller.lifecycle | indent 12 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.controller.extraVolumeMounts }}
+          {{- if or .Values.controller.extraVolumeMounts .Values.aws.licenseConfigSecretName }}
           volumeMounts:
+            {{- if .Values.aws.licenseConfigSecretName }}
+            - name: aws-product-license
+              readOnly: true
+              mountPath: /var/run/secrets/product-license
+            {{- end }}
             {{- if eq "string" (printf "%T" .Values.controller.extraVolumeMounts) }}
 {{ tpl .Values.controller.extraVolumeMounts . | indent 12 }}
-            {{- else }}
+            {{- else if gt (len .Values.controller.extraVolumeMounts) 0 }}
 {{ toYaml .Values.controller.extraVolumeMounts | indent 12 }}
             {{- end }}
           {{- end}}
@@ -212,11 +217,17 @@ spec:
 {{ toYaml .Values.controller.extraContainers | indent 8 }}
           {{- end }}
         {{- end }}
-      {{- if .Values.controller.extraVolumes }}
+      {{- if or .Values.controller.extraVolumes .Values.aws.licenseConfigSecretName }}
       volumes:
+        {{- if .Values.aws.licenseConfigSecretName }}
+        - name: aws-product-license
+          secret:
+            secretName: {{ .Values.aws.licenseConfigSecretName }}
+            optional: true
+        {{- end }}
         {{- if eq "string" (printf "%T" .Values.controller.extraVolumes) }}
 {{ tpl .Values.controller.extraVolumes . | indent 8 }}
-        {{- else }}
+        {{- else if gt (len .Values.controller.extraVolumes) 0 }}
 {{ toYaml .Values.controller.extraVolumes | indent 8 }}
         {{- end }}
       {{- end }}

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -167,6 +167,15 @@ spec:
             timeoutSeconds: {{ .Values.controller.startupProbe.timeoutSeconds }}
           {{- end }}
           env:
+          {{- if .Values.aws.licenseConfigSecretName }}
+          - name: AWS_WEB_IDENTITY_REFRESH_TOKEN_FILE
+            value: "/var/run/secrets/product-license/license_token"
+          - name: AWS_ROLE_ARN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.aws.licenseConfigSecretName }}
+                key: iam_role
+          {{- end }}
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -174,10 +174,10 @@ spec:
           - name: AWS_WEB_IDENTITY_REFRESH_TOKEN_FILE
             value: "/var/run/secrets/product-license/license_token"
           - name: AWS_ROLE_ARN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aws.licenseConfigSecretName }}
-                  key: iam_role
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.aws.licenseConfigSecretName }}
+                key: iam_role
           {{- end }}
           - name: POD_NAME
             valueFrom:
@@ -209,7 +209,7 @@ spec:
             {{- end }}
             {{- if eq "string" (printf "%T" .Values.controller.extraVolumeMounts) }}
 {{ tpl .Values.controller.extraVolumeMounts . | indent 12 }}
-            {{- else }}
+            {{- else if gt (len .Values.controller.extraVolumeMounts) 0 }}
 {{ toYaml .Values.controller.extraVolumeMounts | indent 12 }}
             {{- end }}
           {{- end}}
@@ -230,7 +230,7 @@ spec:
         {{- end }}
         {{- if eq "string" (printf "%T" .Values.controller.extraVolumes) }}
 {{ tpl .Values.controller.extraVolumes . | indent 8 }}
-        {{- else }}
+        {{- else if gt (len .Values.controller.extraVolumes) 0 }}
 {{ toYaml .Values.controller.extraVolumes | indent 8 }}
         {{- end }}
       {{- end }}


### PR DESCRIPTION
DaemonSet strategy was missing the required ENV and volumes.

Additionally, the `toYaml` for the `volumes` and `volumeMounts`, when combined with the additional AWS volumes required for the MarketPlace integration, was creating YAML errors, templating something like this:

```yaml
          volumeMounts:
            - name: aws-product-license
              readOnly: true
              mountPath: /var/run/secrets/product-license
            - []
      volumes:
        - name: aws-product-license
          secret:
            secretName: foo
            optional: true
        - []
```

It has been fixed with the check `if gt (len .Values.controller.extraVolumes) 0` and `if gt (len .Values.controller.extraVolumeMounts) 0` to avoid printing an empty array. In case of no additional volumes, the specification keys `volumes` and `volumeMounts` are ignored and not rendered.