### PR TITLE
MINOR: add POD_IP environment variable

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -175,6 +175,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           {{- if .Values.controller.extraEnvs -}}
           {{- toYaml .Values.controller.extraEnvs | nindent 10 }}
           {{- end }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -178,6 +178,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           {{- if .Values.controller.extraEnvs -}}
           {{- toYaml .Values.controller.extraEnvs | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
To accomodate a new feature in enterprise ingress controller a new environment variable POD_IP must be present.
This Ingress Controller feature concerns peers management.