### PR TITLE
add new features helm-charts

### DIFF
--- a/haproxy/templates/configmap.yaml
+++ b/haproxy/templates/configmap.yaml
@@ -25,3 +25,15 @@ data:
   haproxy.cfg: |
   {{ tpl .Values.config . | nindent 4 }}
 {{- end }}
+
+{{- if .Values.includes }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: includes
+data:
+{{- range $key, $val := .Values.includes }}
+  {{ $key }}: | {{ $val | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -45,11 +45,16 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}
       annotations:
+      {{- if .Values.checksumConfigMap.enabled }}
         checksum/environment: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.shareProcessNamespace.enabled }}
+      shareProcessNamespace: true
+      {{- end }}
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if $useHostNetwork }}
@@ -74,8 +79,14 @@ spec:
 {{- end }}
       volumes:
         - name: haproxy-config
-          configMap:
-            name: {{ include "haproxy.fullname" . }}
+          projected:
+            sources:
+            - configMap:
+                name: {{ include "haproxy.fullname" . }}
+            {{- if .Values.includes }}
+            - configMap:
+                name: includes
+            {{- end }}
         {{- range $mountedSecret := .Values.mountedSecrets }}
         - name: {{ $mountedSecret.volumeName }}
           secret:
@@ -85,6 +96,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
+        {{- with.Values.sidecarContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
@@ -100,8 +114,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.args.enabled }}
           args:
-            - -f
-            - /usr/local/etc/haproxy/haproxy.cfg
+          {{- range .Values.args.defaults }}
+            - {{ . }}
+          {{- end }}
           {{- range .Values.args.extraArgs }}
             - {{ . }}
           {{- end }}
@@ -124,6 +139,25 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             tcpSocket:
               port: {{ .Values.livenessProbe.tcpSocket.port }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          readinessProbe:
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            tcpSocket:
+              port: {{ .Values.readinessProbe.tcpSocket.port }}
+          {{- end }}
+          startupProbe:
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            tcpSocket:
+              port: {{ .Values.startupProbe.tcpSocket.port }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -44,15 +44,24 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}
       annotations:
+      {{- if .Values.checksumConfigMap.enabled }}
         checksum/environment: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.shareProcessNamespace.enabled }}
+      shareProcessNamespace: true
+      {{- end }}
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+{{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
 {{- if .Values.dnsConfig }}
       dnsConfig:
 {{ toYaml .Values.dnsConfig | indent 8 }}
@@ -70,8 +79,14 @@ spec:
 {{- end }}
       volumes:
         - name: haproxy-config
-          configMap:
-            name: {{ include "haproxy.fullname" . }}
+          projected:
+            sources:
+            - configMap:
+                name: {{ include "haproxy.fullname" . }}
+            {{- if .Values.includes }}
+            - configMap:
+                name: includes
+            {{- end }}
         {{- range $mountedSecret := .Values.mountedSecrets }}
         - name: {{ $mountedSecret.volumeName }}
           secret:
@@ -81,6 +96,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
+        {{- with.Values.sidecarContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
@@ -96,8 +114,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.args.enabled }}
           args:
-            - -f
-            - /usr/local/etc/haproxy/haproxy.cfg
+          {{- range .Values.args.defaults }}
+            - {{ . }}
+          {{- end }}
           {{- range .Values.args.extraArgs }}
             - {{ . }}
           {{- end }}
@@ -117,6 +136,25 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             tcpSocket:
               port: {{ .Values.livenessProbe.tcpSocket.port }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          readinessProbe:
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            tcpSocket:
+              port: {{ .Values.readinessProbe.tcpSocket.port }}
+          {{- end }}
+          startupProbe:
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            tcpSocket:
+              port: {{ .Values.startupProbe.tcpSocket.port }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -26,6 +26,50 @@ image:
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
+## Automatically Roll Deployments
+# ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+checksumConfigMap:
+  enabled: true
+
+## Share Process Namespace between Containers in a Pod
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+shareProcessNamespace:
+  enabled: false
+
+## Pods: How Pods manage multiple containers
+# ref: https://kubernetes.io/docs/concepts/workloads/pods/#workload-resources-for-managing-pods
+# ref: https://kubernetes.io/docs/concepts/workloads/pods/#how-pods-manage-multiple-containers
+sidecarContainers: []
+## Reflex
+# ref: https://github.com/cespare/reflex
+# ref: https://hub.docker.com/r/acim/go-reflex
+# - name: reflex
+#   image: acim/go-reflex:1.17.3
+#   command: ["reflex", "-d", "fancy"]
+#   workingDir: /usr/local/etc/haproxy
+#   args:
+#     - -svr
+#     - "..data"
+#     - --
+#     - bash
+#     - -c
+#     - 'pkill -SIGUSR2 "haproxy|hapee-lb"'
+#   ports:
+#     - name: tcp
+#       containerPort: 3000
+#       protocol: TCP
+#   imagePullPolicy: IfNotPresent
+#   volumeMounts:
+#     - name: haproxy-config
+#       mountPath: /usr/local/etc/haproxy
+#   resources:
+#     limits:
+#       cpu: 100m
+#       memory: 128Mi
+#     requests:
+#       cpu: 50m
+#       memory: 64Mi
+
 ## Deployment or DaemonSet pod mode
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
@@ -35,18 +79,41 @@ replicaCount: 1   # used only for Deployment mode
 ## Command line arguments to pass to HAProxy
 args:
   enabled: true    # EE images require disabling this due to S6-overlay
+  # ref: http://cbonte.github.io/haproxy-dconv/2.2/management.html#3
+  defaults: ["-f", "/usr/local/etc/haproxy/haproxy.cfg"]
   extraArgs: []    # EE images require disabling this due to S6-overlay
 
-# livenessProbe to deployment and daemonset
+## Controller Container liveness/readiness probe configuration
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   enabled: false
   failureThreshold: 3
   successThreshold: 1
-  initialDelaySeconds: 15
+  initialDelaySeconds: 0
   timeoutSeconds: 1
   tcpSocket:
-    port: 1024   # modify to your config
-  periodSeconds: 20
+    port: 80
+  periodSeconds: 10
+
+readinessProbe:
+  enabled: false
+  failureThreshold: 3
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 10
+
+startupProbe:
+  enabled: false
+  failureThreshold: 20
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 1
 
 ## DaemonSet configuration
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
@@ -149,6 +216,23 @@ config: |
   backend be_main
     server web1 10.0.0.1:8080 check
 
+## Basic features : Maps
+# ref: http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#7.3.1-map
+# ref: http://cbonte.github.io/haproxy-dconv/2.2/intro.html#3.3.8
+includes:
+  # routes.map: |
+  #   www.example.com/v1     www.example2.com/v2
+  #   api.example.com/v1     api.example2.com/v2
+  #   static.example.com/v1  static.example2.com/v2
+  # 200.http: |
+  #   HTTP/1.1 200 OK
+  #   Cache-Control: no-cache
+  #   Connection: close
+  #   Content-Type: text/html
+  #   <html><body><h1>200 OK</h1>
+  #   Check passed.
+  #   </body></html>
+
 ## Additional secrets to mount as volumes
 ## This is expected to be an array of dictionaries specifying the volume name, secret name and mount path
 mountedSecrets: []
@@ -171,6 +255,17 @@ tolerations: []
 ## Node Affinity for pod-node scheduling constraints
 ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+## Topology spread constraints (only used in kind: Deployment)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+topologySpreadConstraints: []
+# - maxSkew: 1
+#   topologyKey: kubernetes.io/zone
+#   whenUnsatisfiable: DoNotSchedule
+#   labelSelector:
+#     matchLabels:
+#       app.kubernetes.io/name: kubernetes-ingress
+#       app.kubernetes.io/instance: kubernetes-ingress
 
 ## Pod DNS Config
 ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/


### PR DESCRIPTION
Add new features HAProxy helm-charts:
- Automatically Roll Deployments(Helm) - enable/disable
- Share Process Namespace between Containers in a Pod
- Pods: How Pods manage multiple containers - sidecarContainers
- Change defaults command line arguments
- Controller Container liveness/readiness probe configuration
- Basic features : Maps - includes
- Topology spread constraints (only used in kind: Deployment)