### PR TITLE
added config annotation field in kubernetes ingress chart;

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: kubernetes-ingress
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 type: application
-version: 1.17.12
+version: 1.17.11
 appVersion: 1.7.3
 kubeVersion: ">=1.17.0-0"
 keywords:

--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: kubernetes-ingress
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 type: application
-version: 1.17.11
+version: 1.17.12
 appVersion: 1.7.3
 kubeVersion: ">=1.17.0-0"
 keywords:

--- a/kubernetes-ingress/templates/controller-configmap.yaml
+++ b/kubernetes-ingress/templates/controller-configmap.yaml
@@ -25,6 +25,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- if .Values.controller.configAnnotations }}
+  annotations:
+{{ toYaml .Values.controller.configAnnotations | indent 4 }}
+{{- end }}
 data:
 {{- if .Values.controller.logging.traffic }}
   syslog-server: {{ template "kubernetes-ingress.syslogServer" . }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -284,6 +284,10 @@ controller:
   #   rate-limit-interval: "10s"
   #   rate-limit-size: "100k"
 
+  ## Extra annotation for custom configmap for Controller
+  configAnnotations: {}
+  #   annotationKey: value
+
   ## Controller Logging configuration
   logging:
     ## Controller logging level


### PR DESCRIPTION
Added a field `.controller.configAnnotations` to kubernetes-ingress helm chart to allow annotation customization on configmap.

Resolve issue https://github.com/haproxytech/kubernetes-ingress/issues/399

Signed-off-by: Ethern Su <ehaprime@gmail.com>