### PR TITLE
bug: fix volumeMounts with used custom defaults args

### DIFF
--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -172,8 +172,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: haproxy-config
-              mountPath: /usr/local/etc/haproxy/haproxy.cfg
-              subPath: haproxy.cfg
+              mountPath: /usr/local/etc/haproxy
             {{- with.Values.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -169,8 +169,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: haproxy-config
-              mountPath: /usr/local/etc/haproxy/haproxy.cfg
-              subPath: haproxy.cfg
+              mountPath: /usr/local/etc/haproxy
             {{- with.Values.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
When used custom args, example - config_dir, helm-charts is not working.