### PR TITLE
fix: Default TLS secret cannot be generated

### DIFF
--- a/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
+++ b/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
@@ -15,7 +15,7 @@ limitations under the License.
 */}}
 
 {{- if .Values.controller.defaultTLSSecret.enabled }}
-{{- if and .Values.controller.defaultTLSSecret.secret .Values.controller.defaultTLSSecret.secretNamespace }}
+{{- if and (not .Values.controller.defaultTLSSecret.secret) .Values.controller.defaultTLSSecret.secretNamespace }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls


### PR DESCRIPTION
To use a default TLS secret the `controller.defaultTLSSecret.secret` needs to be empty, yet the secret-generating template requires it to be non-empty.
This fix negates the condition on the key to restore desired functionality.

Original functionality:
Setting `controller.defaultTLSSecret.secret` to `null` (default) would not generate a default secret and yet pass its name to the Deployment, generating "secret missing" errors.