### PR TITLE
Add configurable minReadySeconds value

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -33,7 +33,7 @@ metadata:
 {{ toYaml .Values.controller.extraLabels | indent 4 }}
     {{- end }}
 spec:
-  minReadySeconds: 0
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -33,6 +33,7 @@ spec:
   {{- if and (not .Values.controller.autoscaling.enabled) (not .Values.controller.keda.enabled) }}
   replicas: {{ .Values.controller.replicaCount }}
   {{- end }}
+  minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -319,7 +319,7 @@ controller:
   service:
     enabled: true     # set to false when controller.kind is 'DaemonSet' and controller.daemonset.useHostPorts is true
 
-    type: NodePort    # can be 'NodePort' or 'LoadBalancer'
+    type: NodePort    # can be 'ClusterIP', 'NodePort' or 'LoadBalancer'
 
     ## Service annotations
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -55,6 +55,10 @@ controller:
   kind: Deployment    # can be 'Deployment' or 'DaemonSet'
   replicaCount: 2
 
+  ## minReadySeconds setting of Deployment or DaemonSet
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#min-ready-seconds
+  minReadySeconds: 0
+
   ## Running container without root privileges
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   unprivileged: false


### PR DESCRIPTION
- [x] Add configurable minReadySeconds value
- [x] update comment on service type. (Sometimes we only need ClusterIP service for ServiceMonitor, use hostport to exposure.)