### PR TITLE
feat: allow to set several probe more freely.

### DIFF
--- a/haproxy/ci/daemonset-probes-values.yaml
+++ b/haproxy/ci/daemonset-probes-values.yaml
@@ -1,8 +1,27 @@
 kind: DaemonSet
 replicaCount: 2
 livenessProbe:
-  enabled: true
+  failureThreshold: 3
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 10
 readinessProbe:
-  enabled: true
+  failureThreshold: 3
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 10
 startupProbe:
-  enabled: true
+  enabled: false
+  failureThreshold: 20
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 1

--- a/haproxy/ci/deployment-probes-values.yaml
+++ b/haproxy/ci/deployment-probes-values.yaml
@@ -1,7 +1,26 @@
 kind: Deployment
 livenessProbe:
-  enabled: true
+  failureThreshold: 3
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 10
 readinessProbe:
-  enabled: true
+  failureThreshold: 3
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 10
 startupProbe:
-  enabled: true
+  enabled: false
+  failureThreshold: 20
+  successThreshold: 1
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  tcpSocket:
+    port: 80
+  periodSeconds: 1

--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -130,36 +130,12 @@ spec:
               hostPort: {{ index $hostPorts $key | default $value }}
               {{- end }}
           {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            tcpSocket:
-              port: {{ .Values.livenessProbe.tcpSocket.port }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            tcpSocket:
-              port: {{ .Values.readinessProbe.tcpSocket.port }}
-          {{- end }}
-          {{- if .Values.startupProbe.enabled }}
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           startupProbe:
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-            successThreshold: {{ .Values.startupProbe.successThreshold }}
-            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-            tcpSocket:
-              port: {{ .Values.startupProbe.tcpSocket.port }}
-          {{- end }}
+            {{- toYaml .Values.startupProbe | trim | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.lifecycle }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -127,36 +127,12 @@ spec:
               containerPort: {{ $value }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.livenessProbe.successThreshold }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            tcpSocket:
-              port: {{ .Values.livenessProbe.tcpSocket.port }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+            {{- toYaml .Values.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            tcpSocket:
-              port: {{ .Values.readinessProbe.tcpSocket.port }}
-          {{- end }}
-          {{- if .Values.startupProbe.enabled }}
+            {{- toYaml .Values.readinessProbe | trim | nindent 12 }}
           startupProbe:
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-            successThreshold: {{ .Values.startupProbe.successThreshold }}
-            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
-            tcpSocket:
-              port: {{ .Values.startupProbe.tcpSocket.port }}
-          {{- end }}
+            {{- toYaml .Values.startupProbe | trim | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.lifecycle }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -85,35 +85,36 @@ args:
 
 ## Controller Container liveness/readiness probe configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  enabled: false
-  failureThreshold: 3
-  successThreshold: 1
-  initialDelaySeconds: 0
-  timeoutSeconds: 1
-  tcpSocket:
-    port: 80
-  periodSeconds: 10
+livenessProbe: 
+  {}
+  # failureThreshold: 3
+  # successThreshold: 1
+  # initialDelaySeconds: 0
+  # timeoutSeconds: 1
+  # tcpSocket:
+  #   port: 80
+  # periodSeconds: 10
 
 readinessProbe:
-  enabled: false
-  failureThreshold: 3
-  successThreshold: 1
-  initialDelaySeconds: 0
-  timeoutSeconds: 1
-  tcpSocket:
-    port: 80
-  periodSeconds: 10
+  {}
+  # failureThreshold: 3
+  # successThreshold: 1
+  # initialDelaySeconds: 0
+  # timeoutSeconds: 1
+  # tcpSocket:
+  #   port: 80
+  # periodSeconds: 10
 
 startupProbe:
-  enabled: false
-  failureThreshold: 20
-  successThreshold: 1
-  initialDelaySeconds: 0
-  timeoutSeconds: 1
-  tcpSocket:
-    port: 80
-  periodSeconds: 1
+  {}
+  # enabled: false
+  # failureThreshold: 20
+  # successThreshold: 1
+  # initialDelaySeconds: 0
+  # timeoutSeconds: 1
+  # tcpSocket:
+  #   port: 80
+  # periodSeconds: 1
 
 ## DaemonSet configuration
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -130,42 +130,12 @@ spec:
               hostPort: {{ .port }}
               {{- end }}
           {{- end }}
-          {{- if .Values.controller.livenessProbe.enabled }}
           livenessProbe:
-            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-            httpGet:
-              path: {{ .Values.controller.livenessProbe.path }}
-              port: {{ .Values.controller.livenessProbe.port }}
-              scheme: {{ .Values.controller.livenessProbe.scheme }}
-            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.controller.readinessProbe.enabled }}
+            {{- toYaml .Values.controller.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
-            httpGet:
-              path: {{ .Values.controller.readinessProbe.path }}
-              port: {{ .Values.controller.readinessProbe.port }}
-              scheme: {{ .Values.controller.readinessProbe.scheme }}
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.controller.startupProbe.enabled }}
+            {{- toYaml .Values.controller.readinessProbe | trim | nindent 12 }}
           startupProbe:
-            failureThreshold: {{ .Values.controller.startupProbe.failureThreshold }}
-            httpGet:
-              path: {{ .Values.controller.startupProbe.path }}
-              port: {{ .Values.controller.startupProbe.port }}
-              scheme: {{ .Values.controller.startupProbe.scheme }}
-            initialDelaySeconds: {{ .Values.controller.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.startupProbe.periodSeconds }}
-            successThreshold: {{ .Values.controller.startupProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.controller.startupProbe.timeoutSeconds }}
-          {{- end }}
+            {{- toYaml .Values.controller.startupProbe | trim | nindent 12 }}
           env:
           - name: POD_NAME
             valueFrom:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -125,51 +125,12 @@ spec:
               containerPort: {{ .targetPort }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.controller.livenessProbe.enabled }}
           livenessProbe:
-            failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-            httpGet:
-              path: {{ .Values.controller.livenessProbe.path }}
-              port: {{ .Values.controller.livenessProbe.port }}
-              scheme: {{ .Values.controller.livenessProbe.scheme }}
-              {{- if .Values.controller.livenessProbe.httpHeaders }}
-              httpHeaders: {{ toYaml .Values.controller.livenessProbe.httpHeaders | nindent 16 }}
-              {{- end }}
-            initialDelaySeconds: {{ .Values.controller.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.livenessProbe.periodSeconds }}
-            successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.controller.readinessProbe.enabled }}
+            {{- toYaml .Values.controller.livenessProbe | trim | nindent 12 }}
           readinessProbe:
-            failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
-            httpGet:
-              path: {{ .Values.controller.readinessProbe.path }}
-              port: {{ .Values.controller.readinessProbe.port }}
-              scheme: {{ .Values.controller.readinessProbe.scheme }}
-              {{- if .Values.controller.readinessProbe.httpHeaders }}
-              httpHeaders: {{ toYaml .Values.controller.readinessProbe.httpHeaders | nindent 16 }}
-              {{- end }}
-            initialDelaySeconds: {{ .Values.controller.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.readinessProbe.periodSeconds }}
-            successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.controller.startupProbe.enabled }}
+            {{- toYaml .Values.controller.readinessProbe | trim | nindent 12 }}
           startupProbe:
-            failureThreshold: {{ .Values.controller.startupProbe.failureThreshold }}
-            httpGet:
-              path: {{ .Values.controller.startupProbe.path }}
-              port: {{ .Values.controller.startupProbe.port }}
-              scheme: {{ .Values.controller.startupProbe.scheme }}
-              {{- if .Values.controller.startupProbe.httpHeaders }}
-              httpHeaders: {{ toYaml .Values.controller.startupProbe.httpHeaders | nindent 16 }}
-              {{- end }}
-            initialDelaySeconds: {{ .Values.controller.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.controller.startupProbe.periodSeconds }}
-            successThreshold: {{ .Values.controller.startupProbe.successThreshold }}
-            timeoutSeconds: {{ .Values.controller.startupProbe.timeoutSeconds }}
-          {{- end }}
+            {{- toYaml .Values.controller.startupProbe | trim | nindent 12 }}
           env:
           - name: POD_NAME
             valueFrom:

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -97,37 +97,38 @@ controller:
   ## Controller Container liveness/readiness probe configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   livenessProbe:
-    enabled: true
     failureThreshold: 3
     initialDelaySeconds: 0
-    path: /healthz
     periodSeconds: 10
-    port: 1042
-    scheme: HTTP
     successThreshold: 1
     timeoutSeconds: 1
+    httpGet:
+      path: /healthz
+      port: 1042
+      scheme: HTTP
 
   readinessProbe:
-    enabled: true
     failureThreshold: 3
     initialDelaySeconds: 0
-    path: /healthz
     periodSeconds: 10
-    port: 1042
-    scheme: HTTP
     successThreshold: 1
     timeoutSeconds: 1
+    httpGet:
+      path: /healthz
+      port: 1042
+      scheme: HTTP
 
   startupProbe:
-    enabled: true
     failureThreshold: 20
     initialDelaySeconds: 0
-    path: /healthz
     periodSeconds: 1
-    port: 1042
-    scheme: HTTP
     successThreshold: 1
     timeoutSeconds: 1
+    httpGet:
+      path: /healthz
+      port: 1042
+      scheme: HTTP
+    
 
   ## IngressClass:
   ## Ref: https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/ingressclass.md


### PR DESCRIPTION
Hi team, these helm charts are very good.
However, in my case, I needed to set up the exec command in readinessProbe. 
Therefore, I have made some changes in this PR to freely declare the values of several probes.