### PR TITLE
fix(haproxy): ci error for instaliing haproxy chart.

### DIFF
--- a/haproxy/ci/daemonset-probes-values.yaml
+++ b/haproxy/ci/daemonset-probes-values.yaml
@@ -17,7 +17,6 @@ readinessProbe:
     port: 80
   periodSeconds: 10
 startupProbe:
-  enabled: false
   failureThreshold: 20
   successThreshold: 1
   initialDelaySeconds: 0

--- a/haproxy/ci/deployment-probes-values.yaml
+++ b/haproxy/ci/deployment-probes-values.yaml
@@ -16,7 +16,6 @@ readinessProbe:
     port: 80
   periodSeconds: 10
 startupProbe:
-  enabled: false
   failureThreshold: 20
   successThreshold: 1
   initialDelaySeconds: 0


### PR DESCRIPTION
Hi, team.
I fixed CI error due to [this PR](https://github.com/haproxytech/helm-charts/pull/128).
CI error is bellow:
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(DaemonSet.spec.template.spec.containers[0].startupProbe): unknown field "enabled" in io.k8s.api.core.v1.Probe
```

Signed-off-by: mugioka <okamugi0722@gmail.com>
