### PR TITLE
haproxy: Allow defining externalIPs

### DIFF
--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -41,6 +41,10 @@ spec:
   loadBalancerSourceRanges:
   {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- with .Values.containerPorts }}
   ports:
   {{- range $key, $port := . }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -350,6 +350,10 @@ service:
   # ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/
   loadBalancerSourceRanges: []
 
+  ## Service ExternalIPs
+  # ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips
+  externalIPs: []
+
   ## Service annotations
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   annotations: {}


### PR DESCRIPTION
Allows defining `externalIPs` for the service. 

My use case is to get external-dns automation to work in behind NAT.

ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-ips