### PR TITLE
feat(haproxy): additional metrics for HPA.

### DIFF
--- a/haproxy/templates/hpa.yaml
+++ b/haproxy/templates/hpa.yaml
@@ -41,4 +41,7 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+  {{- with .Values.autoscaling.additionalMetrics }}
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -324,6 +324,18 @@ autoscaling:
   maxReplicas: 7
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # additionalMetrics:
+  #   - type: Object
+  #     object:
+  #       metric:
+  #         name: requests-per-second
+  #       describedObject:
+  #         apiVersion: networking.k8s.io/v1
+  #         kind: Ingress
+  #         name: main-route
+  #       target:
+  #         type: Value
+  #         value: 10k
 
 ## Pod Disruption Budget
 ## Only to be used with Deployment kind


### PR DESCRIPTION
Hi team.

Since i want to configure [RPS metrics](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics) in HPA, we can configure additional metrics as additionalMetrics in this PR.

Signed-off-by: mugioka <okamugi0722@gmail.com>