### PR TITLE
add namespaceOverride template to manifests

### DIFF
--- a/haproxy/templates/NOTES.txt
+++ b/haproxy/templates/NOTES.txt
@@ -42,7 +42,7 @@ initContainers:
       privileged: true
 
 Node IP can be found with:
-  $ kubectl --namespace {{ .Release.Namespace }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}"
+  $ kubectl --namespace {{ template "haproxy.namespace" . }} get nodes -o jsonpath="{.items[0].status.addresses[1].address}"
 
 For more examples and up to date documentation, please visit:
   * Helm chart documentation: https://github.com/haproxytech/helm-charts/tree/main/haproxy

--- a/haproxy/templates/_helpers.tpl
+++ b/haproxy/templates/_helpers.tpl
@@ -22,6 +22,17 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "haproxy.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/haproxy/templates/_helpers.tpl
+++ b/haproxy/templates/_helpers.tpl
@@ -25,11 +25,11 @@ Expand the name of the chart.
 Allow the release namespace to be overridden for multi-namespace deployments in combined charts
 */}}
 {{- define "haproxy.namespace" -}}
-  {{- if .Values.namespaceOverride -}}
-    {{- .Values.namespaceOverride -}}
-  {{- else -}}
-    {{- .Release.Namespace -}}
-  {{- end -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -22,6 +22,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   {{- if .Values.podAnnotations }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -19,6 +19,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   {{- if .Values.podAnnotations }}

--- a/haproxy/templates/hpa.yaml
+++ b/haproxy/templates/hpa.yaml
@@ -20,6 +20,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 spec:

--- a/haproxy/templates/ingress.yaml
+++ b/haproxy/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   {{- with .Values.ingress.labels }}

--- a/haproxy/templates/keda.yaml
+++ b/haproxy/templates/keda.yaml
@@ -19,6 +19,7 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   {{- if .Values.keda.scaledObject.annotations }}

--- a/haproxy/templates/poddisruptionbudget.yaml
+++ b/haproxy/templates/poddisruptionbudget.yaml
@@ -19,6 +19,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 spec:

--- a/haproxy/templates/podsecuritypolicy.yaml
+++ b/haproxy/templates/podsecuritypolicy.yaml
@@ -26,6 +26,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 {{- if .Values.podSecurityPolicy.annotations }}

--- a/haproxy/templates/pullsecret.yaml
+++ b/haproxy/templates/pullsecret.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson

--- a/haproxy/templates/role.yaml
+++ b/haproxy/templates/role.yaml
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "haproxy.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 rules:

--- a/haproxy/templates/rolebinding.yaml
+++ b/haproxy/templates/rolebinding.yaml
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "haproxy.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
 roleRef:

--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   annotations:

--- a/haproxy/templates/serviceaccount.yaml
+++ b/haproxy/templates/serviceaccount.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "haproxy.serviceAccountName" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/haproxy/templates/servicemonitor.yaml
+++ b/haproxy/templates/servicemonitor.yaml
@@ -19,7 +19,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "haproxy.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
     {{- if .Values.serviceMonitor.extraLabels }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -25,8 +25,7 @@ serviceAccount:
 ## If namespaceOverride is set, helm will use it's value instead of .Release.Namespace for all chart components.
 ## It is useful in case Haproxy is used as a dependency for another helm chart. Value can be overridden in parent chart values.yaml
 ## Example values.yaml of parent chart:
-## haproxy:
-##   namespaceOverride: haproxytech
+# namespaceOverride: haproxytech
 
 ## Default values for image
 image:

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -21,6 +21,13 @@ serviceAccount:
   create: true
   name:
 
+## Override namespace for for the whole chart
+## If namespaceOverride is set, helm will use it's value instead of .Release.Namespace for all chart components.
+## It is useful in case Haproxy is used as a dependency for another helm chart. Value can be overridden in parent chart values.yaml
+## Example values.yaml of parent chart:
+## haproxy:
+##   namespaceOverride: haproxytech
+
 ## Default values for image
 image:
   repository: haproxytech/haproxy-alpine    # can be changed to use CE or EE images


### PR DESCRIPTION
This PR adds a way to override namespace for Haproxy helm chart if it is being used as dependency in another helm (umbrella) chart.