### PR TITLE
 namespaceOverride not used for configMaps

### DIFF
--- a/haproxy/templates/configmap.yaml
+++ b/haproxy/templates/configmap.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "haproxy.fullname" . }}
+  namespace: {{ template "haproxy.namespace" . }}
   labels:
   {{- include "haproxy.labels" . | nindent 4 }}
 data:
@@ -32,6 +33,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: includes
+  namespace: {{ template "haproxy.namespace" . }}
 data:
 {{- range $key, $val := .Values.includes }}
   {{ $key }}: | {{ $val | nindent 4 }}


### PR DESCRIPTION
During testing of namespaceOverride I've noticed that everything is deployed as expected except configMaps, they are still deployed in the `.Release.namespace`