### PR TITLE
increment chart version to reflect upgrade to 2.6.6

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: haproxy
 description: A Helm chart for HAProxy on Kubernetes
 type: application
-version: 1.17.0
+version: 1.18.0
 appVersion: 2.6.6
 kubeVersion: ">=1.17.0-0"
 keywords:


### PR DESCRIPTION
when image was upgraded to 2.6.6 chart version was not incremented so helm does not update it. this change increments chart version to trigger helm upgrades