### PR TITLE
REORG/MINOR: removing leading dashes from CRDs manifests

### DIFF
--- a/kubernetes-ingress/crds/core.haproxy.org_backends.yaml
+++ b/kubernetes-ingress/crds/core.haproxy.org_backends.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/kubernetes-ingress/crds/core.haproxy.org_defaults.yaml
+++ b/kubernetes-ingress/crds/core.haproxy.org_defaults.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/kubernetes-ingress/crds/core.haproxy.org_globals.yaml
+++ b/kubernetes-ingress/crds/core.haproxy.org_globals.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Listing on AWS MarketPlace requires CRDs manifests to be non-leaded by dashes (`---`).

Tested on a `kind` installation.

```
$: kind create cluster --name haproxy
Creating cluster "haproxy" ...
 ✓ Ensuring node image (kindest/node:v1.25.3) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-haproxy"
You can now use your cluster with:

kubectl cluster-info --context kind-haproxy

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
```

```
$: git log --name-status HEAD^..HEAD
commit 5cb74fb678446bb3b05723cb59eb6dea572170fc (HEAD -> crds, origin/crds)
Author: Dario Tranchitella <dario@tranchitella.eu>
Date:   Mon Nov 21 18:16:35 2022 +0100

    REORG/MINOR: removing leading dashes from CRDs manifests

M       kubernetes-ingress/crds/core.haproxy.org_backends.yaml
M       kubernetes-ingress/crds/core.haproxy.org_defaults.yaml
M       kubernetes-ingress/crds/core.haproxy.org_globals.yaml
```

```
$: helm upgrade --install kubernetes-ingress ./kubernetes-ingress
Release "kubernetes-ingress" does not exist. Installing it now.
NAME: kubernetes-ingress
LAST DEPLOYED: Mon Nov 21 18:19:52 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
HAProxy Kubernetes Ingress Controller has been successfully installed.

Controller image deployed is: "haproxytech/kubernetes-ingress:1.9.0".
Your controller is of a "Deployment" kind. Your controller service is running as a "NodePort" type.
RBAC authorization is enabled.
Controller ingress.class is set to "haproxy" so make sure to use same annotation for
Ingress resource.

Service ports mapped are:
  - name: http
    containerPort: 8080
    protocol: TCP
  - name: https
    containerPort: 8443
    protocol: TCP
  - name: stat
    containerPort: 1024
    protocol: TCP

Node IP can be found with:
  $ kubectl --namespace default get nodes -o jsonpath="{.items[0].status.addresses[1].address}"

The following ingress resource routes traffic to pods that match the following:
  * service name: web
  * client's Host header: webdemo.com
  * path begins with /

  ---
  apiVersion: networking.k8s.io/v1
  kind: Ingress
  metadata:
    name: web-ingress
    namespace: default
    annotations:
      ingress.class: "haproxy"
  spec:
    rules:
    - host: webdemo.com
      http:
        paths:
        - path: /
          backend:
            serviceName: web
            servicePort: 80

In case that you are using multi-ingress controller environment, make sure to use ingress.class annotation and match it
with helm chart option controller.ingressClass.

For more examples and up to date documentation, please visit:
  * Helm chart documentation: https://github.com/haproxytech/helm-charts/tree/main/kubernetes-ingress
  * Controller documentation: https://www.haproxy.com/documentation/kubernetes/latest/
  * Annotation reference: https://github.com/haproxytech/kubernetes-ingress/tree/master/documentation
  * Image parameters reference: https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/controller.md
```

```
$: kubectl get cards
NAME                        CREATED AT
backends.core.haproxy.org   2022-11-21T17:19:52Z
defaults.core.haproxy.org   2022-11-21T17:19:52Z
globals.core.haproxy.org    2022-11-21T17:19:52Z
```