### PR TITLE
Supporting enableServiceLinks pod spec configuration

### DIFF
--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -55,6 +55,7 @@ spec:
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
     spec:
+      enableServiceLinks: {{ default true ."Values.controller.enableServiceLinks" }}
       serviceAccountName: {{ template "kubernetes-ingress.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- with .Values.controller.topologySpreadConstraints }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -174,6 +174,10 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}
   #  key: value
+  
+  ## Allows to enable/disable environment variables for finding services
+  ## ref: https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service
+  enableServiceLinks: true
 
   ## Ingress TLS secret, if it is enabled and secret is null then controller will use auto-generated secret, otherwise
   ## secret needs to contain name of the Secret object which has been created manually


### PR DESCRIPTION
This PR extends the `.Values.controller` to allow the configuration of the controller pod spec `enableServiceLinks` property.
 > See: https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service