### PR TITLE
Exposing internal Service for metrics when using LoadBalancer and no stats

### DIFF
--- a/kubernetes-ingress/templates/_helpers.tpl
+++ b/kubernetes-ingress/templates/_helpers.tpl
@@ -134,4 +134,11 @@ Create a default fully qualified ServiceMonitor name.
 {{- default (include "kubernetes-ingress.fullname" .) .Values.controller.serviceMonitor.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Create a FQDN for the Service metrics.
+*/}}
+{{- define "kubernetes-ingress.serviceMetricsName" -}}
+{{- printf "%s-%s" (include "kubernetes-ingress.fullname" . | trunc 56 | trimSuffix "-") "metrics" }}
+{{- end -}}
+
 {{/* vim: set filetype=mustache: */}}

--- a/kubernetes-ingress/templates/controller-service-metrics.yaml
+++ b/kubernetes-ingress/templates/controller-service-metrics.yaml
@@ -1,5 +1,5 @@
 {{/*
-Copyright 2019 HAProxy Technologies LLC
+Copyright 2022 HAProxy Technologies LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubernetes-ingress/templates/controller-service-metrics.yaml
+++ b/kubernetes-ingress/templates/controller-service-metrics.yaml
@@ -1,0 +1,63 @@
+{{/*
+Copyright 2019 HAProxy Technologies LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+The following Service resource will be created upon certain conditions:
+- The ServiceMonitor integration is enabled
+- A Service resource must be created
+- The stats port is not exposed
+- The Service is type LoadBalancer
+
+The reason for that is that the Ingress Controller would make it available to the outside
+sensitive data such as its metrics, and the operator wants to keep these data private
+(such as the value of "controller.service.enablePorts.stat=false").
+
+To let the Prometheus Operator being able to scrape the metrics, an additional service
+is going to be created, allowing it to expose of these in the internal Kubernetes networking.
+*/}}
+{{- if and (.Values.controller.serviceMonitor.enabled) (.Values.controller.service.enabled) (not .Values.controller.service.enablePorts.stat) (eq .Values.controller.service.type "LoadBalancer") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kubernetes-ingress.serviceMetricsName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+    helm.sh/chart: {{ template "kubernetes-ingress.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- if .Values.controller.service.labels }}
+{{ toYaml .Values.controller.service.labels | indent 4 }}
+{{- end }}
+  annotations:
+{{- range $key, $value := .Values.controller.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: stat
+      port: {{ .Values.controller.service.ports.stat }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.stat }}
+    {{- if .Values.controller.service.nodePorts.stat }}
+      nodePort: {{ .Values.controller.service.nodePorts.stat }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "kubernetes-ingress.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}


### PR DESCRIPTION
This is an enhancement for an edge case.

Suppose the Kubernetes Ingress Controller is deployed using the Service type of LoadBalancer. In that case, the `stats` port will be public too, letting any potential attacker gather information about the metrics, and the internal endpoints, and reverse engineering the name of the service.

This can be prevented by installing the Ingress Controllers with the value `controller.service.enablePorts.stat=false` that will remove the `stats` port from the Service definition exposed using the type LoadBalancer.

However, this will break the Prometheus Operator integration through the `ServiceMonitor` resources, since the `EndpointSlice` objects will not contain anymore any available endpoint pointing to the stats port.

The proposed solution is to create a second service name `{release-name}-metrics` that will contain the metrics port in order to let the ServiceMonitor properly fetch the required endpoints.