### PR TITLE
fix(haproxy): add additionalPorts to service

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: haproxy
 description: A Helm chart for HAProxy on Kubernetes
 type: application
-version: 1.17.5
+version: 1.17.6
 appVersion: 2.6.6
 kubeVersion: ">=1.17.0-0"
 keywords:
@@ -31,4 +31,4 @@ maintainers:
 engine: gotpl
 annotations:
   artifacthub.io/changes: |
-    - Fix HPA spec
+    - Add possibility to pass additional ports to Service

--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -46,12 +46,22 @@ spec:
   externalIPs:
   {{- toYaml . | nindent 2 }}
   {{- end }}
-  {{- with .Values.containerPorts }}
+  {{- if or .Values.containerPorts .Values.service.additionalPorts }}
   ports:
+  {{- with .Values.containerPorts }}
   {{- range $key, $port := . }}
   - name: {{ $key }}
     protocol: TCP
     port: {{ $port }}
     targetPort: {{ $key }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.service.additionalPorts }}
+  {{- range $key, $port := . }}
+  - name: {{ $key }}
+    protocol: TCP
+    port: {{ $port }}
+    targetPort: {{ $key }}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -468,6 +468,11 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
   # externalTrafficPolicy: Cluster
 
+  ## Additional Service ports to use(e.g. port of side container haproxy exporter)
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+  additionalPorts: {}
+    # prometheus: 9101
+
 serviceMonitor:
   ## Toggle the ServiceMonitor true if you have Prometheus Operator installed and configured
   enabled: false


### PR DESCRIPTION
We want to scrape metrics of haproxy. We are using [haproxy exporter](https://github.com/prometheus/haproxy_exporter) as a side container to haproxy. However, now there is no possibility to add port of a side container to Service. This is needed for ServiceMonitor. 

This PR adds additionalPorts spec to pass ports of a side containers.