### PR TITLE
MINOR: Add note in rollingUpdate strategy section for DaemonSet

### DIFF
--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -443,8 +443,8 @@ controller:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
+      maxUnavailable: 0 # set a non-zero value when controller.kind is 'DaemonSet'
+      maxSurge: 1 # set to 0 when controller.kind is 'DaemonSet'
 
   ## Controller Pod PriorityClass
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
This PR adds two notes for those who need to deploy ingress-controller in DaemonSet mode.
Here is the default values behavior with DaemonSet:
```yaml
controller:
...
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
...
```
Behavior: new pod will be created but it will stuck in Pending status forever, 
```
0/9 nodes are available: 1 node(s) didn't have free ports for the requested pod ports. preemption: 0/9 nodes are available: 9 No preemption victims found for incoming pod.
``` 