### PR TITLE
Reordering resources list in hpa

### DIFF
--- a/haproxy/templates/hpa.yaml
+++ b/haproxy/templates/hpa.yaml
@@ -37,14 +37,6 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-  {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -52,6 +44,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- with .Values.autoscaling.additionalMetrics }}
     {{- toYaml . | trim | nindent 4 }}


### PR DESCRIPTION
If you enabled the HPA and deploy with ArgoCD, the helm chart will always be detected as "OutOfSync" since k8ts will sort the resources list in the hpa cdr.

Have a look here for more info: https://github.com/argoproj/argo-cd/issues/1079