### PR TITLE
fix: includes name in haproxy charts

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: haproxy
 description: A Helm chart for HAProxy on Kubernetes
 type: application
-version: 1.19.2
+version: 1.19.3
 appVersion: 2.8.1
 kubeVersion: ">=1.17.0-0"
 keywords:

--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -87,7 +87,7 @@ spec:
           projected:
             sources:
             - configMap:
-                name: includes
+                name: {{ include "haproxy.includes" . }}
         {{- end }}
         {{- range $mountedSecret := .Values.mountedSecrets }}
         - name: {{ $mountedSecret.volumeName }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
           projected:
             sources:
             - configMap:
-                name: includes
+                name: {{ include "haproxy.includes" . }}
         {{- end }}
         {{- range $mountedSecret := .Values.mountedSecrets }}
         - name: {{ $mountedSecret.volumeName }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -259,7 +259,7 @@ includes:
   #   </body></html>
 
 ## Mount path for includes and maps
-includesMountPath: /usr/local/etc/haproxy         # EE images use /etc/hapee-VERSION
+includesMountPath: /usr/local/etc/haproxy/includes         # EE images use /etc/hapee-VERSION
 
 ## Additional secrets to mount as volumes
 ## This is expected to be an array of dictionaries specifying the volume name, secret name and mount path


### PR DESCRIPTION
- The `haproxy` chart is broken. It will always show this error `MountVolume.SetUp failed for volume "includes" : configmap "includes" not found`
  - This is due to this issue: the `includes` configmap name is supposed to be updated to `{{ include "haproxy.includes" . }}` instead of `includes` only
- The `includesMountPath` cannot be clashing with `haproxy.cfg` path. The existing default will always throw error `flags: 0x5001: not a directory: unknown`