### PR TITLE
haproxy: only defined hostPorts for DaemonSet

### DIFF
--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -121,8 +121,8 @@ spec:
             - name: {{ $key }}
               containerPort: {{ $value }}
               protocol: TCP
-              {{- if $useHostPort }}
-              hostPort: {{ index $hostPorts $key | default $value }}
+              {{- if and $useHostPort (index $hostPorts $key) }}
+              hostPort: {{ index $hostPorts $key }}
               {{- end }}
           {{- end }}
           {{- with .Values.livenessProbe }}


### PR DESCRIPTION
This change exposes only those ports that are explicitly defined in daemonset.hostPorts. The remaining ports, which are defined only in containerPorts, will only be accessible from within the K8S cluster. This will allow to use one haproxy instance more universally.