### PR TITLE
MEDIUM: ci: Push charts to ghcr.io as OCI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+    - publish-as-oci
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Fetch history
+      run: git fetch --prune --unshallow
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Install Helm
+      uses: azure/setup-helm@v3.5
+      with:
+        version: v3.13.0
+
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.5.0
+      with:
+        charts_dir: .
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        CR_GENERATE_RELEASE_NOTES: true
+
+    # see https://github.com/helm/chart-releaser/issues/183
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push charts to ghcr.io
+      run: |
+        shopt -s nullglob
+        for pkg in .cr-release-packages/*; do
+          if [ -z "${pkg:-}" ]; then
+            break
+          fi
+          helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+        done

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Session.vim
 
 # TODO
 TODO
+
+# release packages
+.cr-release-packages/


### PR DESCRIPTION
Helm [released full OCI support](https://helm.sh/blog/storing-charts-in-oci/) in version 3.8. This PR creates an action to publish the charts to the `ghcr.io` repository.

As a result, the charts can be installed using `helm install haproxy oci://ghcr.io/haproxytech/charts/kubernetes-ingress --version 1.33.1` without the need to manually add and update chart repositories.

 