### PR TITLE
MINOR: add permissions needed for techdump tool

### DIFF
--- a/kubernetes-ingress/templates/clusterrole.yaml
+++ b/kubernetes-ingress/templates/clusterrole.yaml
@@ -117,4 +117,15 @@ rules:
   verbs:
   - update
 {{- end }}
+{{- if .Values.controller.techdump.enabled }}
+- apiGroups:
+  - "apps"
+  resources:
+  - replicasets
+  - deployments
+  - daemonsets
+  verbs:
+  - get
+  - list
+{{- end }}
 {{- end -}}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -533,3 +533,8 @@ controller:
         path: /metrics
         scheme: http
         interval: 30s
+
+  ## Techdump
+  ## Toggle to add the RBAC permissions needed for the techdump tool.
+  techdump:
+    enabled: false


### PR DESCRIPTION
Add the needed permissions to use the `techdump` tool.
New permissions are added only if `.Values.controller.techdump.enabled=true`, in order to not add them by default, only when needed.