### PR TITLE
MINOR: add 'automountServiceAccountToken` property

### DIFF
--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -57,6 +57,9 @@ spec:
     spec:
       enableServiceLinks: {{ .Values.controller.enableServiceLinks }}
       serviceAccountName: {{ include "kubernetes-ingress.serviceAccountName" . }}
+      {{- if hasKey .Values.controller "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.controller.automountServiceAccountToken }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- with .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -538,3 +538,7 @@ controller:
   ## Toggle to add the RBAC permissions needed for the techdump tool.
   techdump:
     enabled: false
+
+  ## automountServiceAccountToken
+  ## Automatically mount a ServiceAccount's API credentials
+  automountServiceAccountToken: true


### PR DESCRIPTION
Added ability to control `automountServiceAccountToken` value, which is defaulted to true.