### PR TITLE
FEATURE/MINOR: haproxy: add 'internalTrafficPolicy' property for service

### DIFF
--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -32,6 +32,9 @@ spec:
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+  {{- end }}
   {{- with .Values.service.clusterIP }}
   clusterIP: {{ . | quote}}
   {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -475,6 +475,10 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
   # externalTrafficPolicy: Cluster
 
+  ## Service internalTrafficPolicy
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+  # internalTrafficPolicy: Cluster
+
   ## Additional Service ports to use(e.g. port of side container haproxy exporter)
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
   additionalPorts: {}


### PR DESCRIPTION
Added the ability to set the internalTrafficPolicy attribute on the Service, which defaults to `Cluster`.

In combination with deploying HAProxy as a DaemonSet, setting internalTrafficPolicy to `Local` allows each Pod to only use the HAProxy instance on its local Node.