### PR TITLE
feat: update podAnnotations rendering for better flexibility.

### DIFF
--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         checksum/environment: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- end }}
       {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.podAnnotations) . | indent 8 }}
       {{- end }}
     spec:
       {{- if .Values.shareProcessNamespace.enabled }}


### PR DESCRIPTION
This modification enhances the flexibility of podAnnotations. It provides the option to utilize evaluation functions for an locale configmap, for example.

In my scenario, I'm using this chart as a dependency, and I have a local configmap. Therefore, I want the pods to rollout when the locale configmap is modified.

```yaml
...

  podAnnotations:
    checksum/local-environment: {{ include (print $.Template.BasePath "/my-local-configmap.yaml") . | sha256sum }}

...
```

This modification doesn't alter the current functionality.