### PR TITLE
chore(haproxy): streamline service port configuration for flexibility

### DIFF
--- a/haproxy/templates/_helpers.tpl
+++ b/haproxy/templates/_helpers.tpl
@@ -103,3 +103,26 @@ Encode an imagePullSecret string.
 {{- end }}
 
 {{/* vim: set filetype=mustache: */}}
+
+{{/*
+Exposed ports to service
+*/}}
+{{- define "haproxy.exposedPorts" }}
+{{- $exposedPorts := .Values.service.exposedPorts }}
+{{- if empty $exposedPorts }}
+{{- $containerPorts := .Values.containerPorts }}
+{{- range $key, $port := $containerPorts }}
+- name: {{ $key }}
+  protocol: TCP
+  port: {{ $port }}
+  targetPort: {{ $key }}
+{{- end }}
+{{- else }}
+{{- range $key, $port := $exposedPorts }}
+- name: {{ $key }}
+  protocol: TCP
+  port: {{ $port }}
+  targetPort: {{ $key }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -51,14 +51,7 @@ spec:
   {{- end }}
   {{- if or .Values.containerPorts .Values.service.additionalPorts }}
   ports:
-  {{- with .Values.containerPorts }}
-  {{- range $key, $port := . }}
-  - name: {{ $key }}
-    protocol: TCP
-    port: {{ $port }}
-    targetPort: {{ $key }}
-  {{- end }}
-  {{- end }}
+  {{- include "haproxy.exposedPorts" . | nindent 3 -}}
   {{- with .Values.service.additionalPorts }}
   {{- range $key, $port := . }}
   - name: {{ $key }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -484,6 +484,12 @@ service:
   additionalPorts: {}
     # prometheus: 9101
 
+  ## Deterministic exposure of ports to the service
+  ## .Values.containerPorts will be exposed if exposedPorts is empty
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+  exposedPorts: {}
+    # http: 80
+
 serviceMonitor:
   ## Toggle the ServiceMonitor true if you have Prometheus Operator installed and configured
   enabled: false


### PR DESCRIPTION
Refactored the service port configuration in the HAProxy Helm chart to allow for more flexible and deterministic exposure of ports. This change introduces a new `exposedPorts` option in `values.yaml`, which, when specified, takes precedence over the default container ports for service exposure. This enhancement facilitates clearer and more customizable service definitions, catering to diverse deployment scenarios.

----


In my case, this feature enables me to expose a port within the pods to configure `peers` without exposing this port through my service.

For my service, I only want to expose ports `80`, `443`, and a few others.