### PR TITLE
FEATURE/MINOR: kubernetes-ingress: Add metrics service-specific metadata

### DIFF
--- a/kubernetes-ingress/templates/controller-service-metrics.yaml
+++ b/kubernetes-ingress/templates/controller-service-metrics.yaml
@@ -40,11 +40,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
-{{- if .Values.controller.service.labels }}
-{{ toYaml .Values.controller.service.labels | indent 4 }}
+{{- if .Values.controller.service.metrics.labels }}
+{{ toYaml .Values.controller.service.metrics.labels | indent 4 }}
 {{- end }}
   annotations:
-{{- range $key, $value := .Values.controller.service.annotations }}
+{{- range $key, $value := .Values.controller.service.metrics.annotations }}
     {{ $key }}: {{ $value | quote }}
 {{- end }}
 spec:

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -460,6 +460,17 @@ controller:
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     # sessionAffinity: ""
 
+    ## Controller Metrics Service configuration
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
+    metrics:
+      ## Service annotations
+      ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+      annotations: {}
+
+      ## Service labels
+      ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+      labels: {}
+
   ## Controller DaemonSet configuration
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
   daemonset:


### PR DESCRIPTION
Adds `controller.service.metrics.labels` and
`controller.service.metrics.annotations` so that the metrics service can have its metadata templated using metadata not shared by the main service.