### PR TITLE
FEATURE/MINOR: kubernetes-ingress: Parametrize metrics service type

### DIFF
--- a/kubernetes-ingress/templates/controller-service-metrics.yaml
+++ b/kubernetes-ingress/templates/controller-service-metrics.yaml
@@ -48,7 +48,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
 {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.controller.service.metrics.type }}
   ports:
     - name: stat
       port: {{ .Values.controller.service.ports.stat }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -463,6 +463,8 @@ controller:
     ## Controller Metrics Service configuration
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
     metrics:
+      type: ClusterIP    # can be 'ClusterIP', 'NodePort' or 'LoadBalancer'
+
       ## Service annotations
       ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
       annotations: {}


### PR DESCRIPTION
Adds `controller.service.metrics.type` so that the metrics service's type can be parametrized. The value defaults to `ClusterIP` for backwards compatibility with previous versions of the Helm chart.

We need the ability to do this because of a [bug in `external-dns`](https://github.com/kubernetes-sigs/external-dns/issues/187) but we unfortunately are not immediately able to upgrade `external-dns` to fix this bug.