### PR TITLE
DOC - logging block is replaced when cr-global is used.

### DIFF
--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -340,6 +340,8 @@ controller:
   #   annotationKey: value
 
   ## Controller Logging configuration
+  ## Careful: this block will be ignored if you use config.cr-global.
+  ## In this case, move your logging config in entry spec.log_targets in your CR.
   logging:
     ## Controller logging level
     ## This only relevant to Controller logs


### PR DESCRIPTION
Related to https://github.com/haproxytech/kubernetes-ingress/issues/633

Warn people that if they use the `logging` block, it will be completely ignored if they also use config.cr-global

