### PR TITLE
BUG: kubernetes-ingress: Replace tpl with default

### DIFF
--- a/haproxy/templates/NOTES.txt
+++ b/haproxy/templates/NOTES.txt
@@ -1,7 +1,7 @@
 HAProxy has been has been successfully installed. This Chart is used to run HAProxy as a regular application,
 as opposed to HAProxy Ingress Controller Chart.
 
-Controller image deployed is: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}".
+Controller image deployed is: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}".
 Your HAProxy app is of a "{{ .Values.kind }}" kind.
 
 Service ports mapped are:

--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -105,7 +105,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- omit .Values.securityContext "enabled" | toYaml  | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.args.enabled }}
           args:

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
           {{- if .Values.securityContext.enabled }}
           securityContext: {{- omit .Values.securityContext "enabled" | toYaml  | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.args.enabled }}
           args:

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -31,7 +31,8 @@ serviceAccount:
 ## Default values for image
 image:
   repository: haproxytech/haproxy-alpine    # can be changed to use CE or EE images
-  tag: "{{ .Chart.AppVersion }}"
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
   pullPolicy: IfNotPresent
 
 ## Automatically Roll Deployments

--- a/kubernetes-ingress/templates/NOTES.txt
+++ b/kubernetes-ingress/templates/NOTES.txt
@@ -1,6 +1,6 @@
 HAProxy Kubernetes Ingress Controller has been successfully installed.
 
-Controller image deployed is: "{{ .Values.controller.image.repository }}:{{ tpl .Values.controller.image.tag . }}".
+Controller image deployed is: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}".
 Your controller is of a "{{ .Values.controller.kind }}" kind. Your controller service is running as a "{{ .Values.controller.service.type }}" type.
 {{- if .Values.rbac.create}}
 RBAC authorization is enabled.

--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -69,7 +69,7 @@ spec:
 {{- end }}
       containers:
         - name: crd
-          image: "{{ .Values.controller.image.repository }}:{{ tpl .Values.controller.image.tag . }}"
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           command:
             - /haproxy-ingress-controller

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -88,7 +88,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ include "kubernetes-ingress.name" . }}-{{ .Values.controller.name }}
-          image: "{{ .Values.controller.image.repository }}:{{ tpl .Values.controller.image.tag . }}"
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
 {{- if .Values.controller.defaultTLSSecret.enabled -}}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -88,7 +88,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ include "kubernetes-ingress.name" . }}-{{ .Values.controller.name }}
-          image: "{{ .Values.controller.image.repository }}:{{ tpl .Values.controller.image.tag . }}"
+          image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
 {{- if .Values.controller.defaultTLSSecret.enabled -}}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -61,7 +61,8 @@ controller:
   name: controller
   image:
     repository: haproxytech/kubernetes-ingress    # can be changed to use CE or EE Controller images
-    tag: "{{ .Chart.AppVersion }}"
+    # Overrides the image tag whose default is the chart appVersion
+    tag: ""
     pullPolicy: IfNotPresent
 
   ## Deployment or DaemonSet pod mode


### PR DESCRIPTION
Follow on from https://github.com/haproxytech/helm-charts/pull/243.

## Summary

Instead of passing a templated string value `tag: "{{ .Chart.AppVersion }}"` and relying on `tpl` inside the templates that consume it, it is safer, less complicated, and more standardized to:

1. Default to a falsey value i.e. `tag: ""`; and
2. place the "or default to the `.Chart.AppVersion`" logic inside the templates that consume that value.

For example, grafana's charts use this same pattern (I lifted it from there):

* https://github.com/grafana/helm-charts/blob/c8b0156b04dcf975ff1dbbbee570ee84503eb659/charts/grafana/values.yaml#L102-L103
* https://github.com/grafana/helm-charts/blob/c8b0156b04dcf975ff1dbbbee570ee84503eb659/charts/grafana/templates/_pod.tpl#L856

## Context

Since `tpl` expects a string, passing an unqouted, fully-numeric image tag value (imagine a git commit SHA1 of `53349267`) results in a helm templating error, e.g.:

```
INFO[0000] install.go:214: [debug] Original chart version: ""
install.go:231: [debug] CHART PATH:
/home/mcampbell/github/coreweave/api-gateway/integration_tests

Error: template:
cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml:91:74:
executing
"cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml"
at <.Values.controller.image.tag>: wrong type for value; expected
string; got int64
helm.go:84: [debug] template:
cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml:91:74:
executing
"cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml"
at <.Values.controller.image.tag>: wrong type for value; expected
string; got int64  subtask=0 task=Render
std out err:
%!(EXTRA *errors.errorString=install.go:214: [debug] Original chart
version: ""
install.go:231: [debug] CHART PATH:
/home/mcampbell/github/coreweave/api-gateway/integration_tests

Error: template:
cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml:91:74:
executing
"cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml"
at <.Values.controller.image.tag>: wrong type for value; expected
string; got int64
helm.go:84: [debug] template:
cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml:91:74:
executing
"cloud-integration-tests/charts/cloud-app/charts/api-gateway/charts/kubernetes-ingress/templates/controller-deployment.yaml"
at <.Values.controller.image.tag>: wrong type for value; expected
string; got int64
```