### PR TITLE
fix(kubernetes-ingress): limit template spec name to 15 characters

### DIFF
--- a/kubernetes-ingress/templates/NOTES.txt
+++ b/kubernetes-ingress/templates/NOTES.txt
@@ -29,7 +29,7 @@ Service ports mapped are:
     protocol: UDP
 {{- end }}
 {{- range .Values.controller.service.tcpPorts }}
-  - name: {{ .name }}-tcp
+  - name: {{ .name | trunc 15 | trimSuffix "-" }}
     containerPort: {{ .targetPort }}
     protocol: TCP
 {{- end }}
@@ -61,7 +61,7 @@ Service ports mapped are:
 {{- end }}
 {{- end }}
 {{- range .Values.controller.service.tcpPorts }}
-  - name: {{ .name }}-tcp
+  - name: {{ .name | trunc 15 | trimSuffix "-" }}
     containerPort: {{ .port }}
     protocol: TCP
 {{- if $useHostPort }}

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -168,7 +168,7 @@ spec:
               {{- end }}
           {{- end }}
           {{- range .Values.controller.service.tcpPorts }}
-            - name: {{ .name }}-tcp
+            - name: {{ .name | trunc 15 | trimSuffix "-" }}
               containerPort: {{ .port }}
               protocol: TCP
               {{- if $useHostPort }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -167,7 +167,7 @@ spec:
               protocol: UDP
           {{- end }}
           {{- range .Values.controller.service.tcpPorts }}
-            - name: {{ .name }}-tcp
+            - name: {{ .name | trunc 15 | trimSuffix "-" }}
               containerPort: {{ .targetPort }}
               protocol: TCP
           {{- end }}

--- a/kubernetes-ingress/templates/controller-proxy-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-proxy-deployment.yaml
@@ -162,7 +162,7 @@ spec:
               protocol: UDP
           {{- end }}
           {{- range .Values.controller.service.tcpPorts }}
-            - name: {{ .name }}-tcp
+            - name: {{ .name | trunc 15 | trimSuffix "-" }}
               containerPort: {{ .targetPort }}
               protocol: TCP
           {{- end }}

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -98,7 +98,7 @@ spec:
     {{- end }}
   {{- end }}
   {{- range .Values.controller.service.tcpPorts }}
-    - name: {{ .name }}-tcp
+    - name: {{ .name | trunc 15 | trimSuffix "-" }}
       port: {{ .port }}
       protocol: TCP
       targetPort: {{ .targetPort }}


### PR DESCRIPTION
This modification introduces two changes in templates:
- remove suffix `-tcp` on template controller.service.tcpPorts's name. Users add this suffix themselves if it's relevant to them.
- limit length to 15 characters max according to RFC6335.
Avoid errors like: 
````
Error: UPGRADE FAILED: cannot patch "release-name" with kind Deployment: Deployment.apps "release-name" is invalid: [spec.template.spec.containers[0].ports[6].name: Invalid value: "name-too-long-tcp": must be no more than 15 characters
````
