### PR TITLE
FEATURE/MINOR: Add ability to specify HPA name in KEDA scaledObject

### DIFF
--- a/kubernetes-ingress/templates/controller-keda.yaml
+++ b/kubernetes-ingress/templates/controller-keda.yaml
@@ -42,11 +42,16 @@ spec:
 {{ end }}
   advanced:
     restoreToOriginalReplicaCount: {{ .Values.controller.keda.restoreToOriginalReplicaCount }}
-{{- if .Values.controller.keda.behavior }}
+{{- if .Values.controller.keda.horizontalPodAutoscalerConfig }}
     horizontalPodAutoscalerConfig:
+{{- if .Values.controller.keda.horizontalPodAutoscalerConfig.name }}
+      name: {{ .Values.controller.keda.horizontalPodAutoscalerConfig.name }}
+{{- end }}
+{{- if .Values.controller.keda.horizontalPodAutoscalerConfig.behavior }}
       behavior:
-{{ with .Values.controller.keda.behavior -}}
+{{ with .Values.controller.keda.horizontalPodAutoscalerConfig.behavior -}}
 {{ toYaml . | indent 8 }}
 {{ end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -257,13 +257,15 @@ controller:
     restoreToOriginalReplicaCount: false
     scaledObject:
       annotations: {}
-    behavior: {}
-    #  scaleDown:
-    #    stabilizationWindowSeconds: 300
-    #    policies:
-    #    - type: Percent
-    #      value: 100
-    #      periodSeconds: 15
+    horizontalPodAutoscalerConfig: {}
+      # name: ""
+      # behavior:
+      #  scaleDown:
+      #    stabilizationWindowSeconds: 300
+      #    policies:
+      #    - type: Percent
+      #      value: 100
+      #      periodSeconds: 15
     triggers: []
     #  - type: prometheus
     #    metadata:


### PR DESCRIPTION
For one of my use cases, I need to be able to specify the name of the HPA object that KEDA's scaledObject will control.
The chart correctly allows one to specify behaviour of the HPA object but not the name of it.
Therefore I:

- Gave the ability to correctly specify `horizontalPodAutoscalerConfig` as the KEDA scaledObject itself has
- Gave the ability to specify the name of the object under this field
- Moved the behaviour block under the `horizontalPodAutoscalerConfig` block, as the original structure of the KEDA object is like this.

Using this configuration in conjunction with specifying the relevant annotations for the KEDA object will correctly have KEDA adopt the HPA object.