### PR TITLE
Add pre-install hook annotation for namespace creation

### DIFF
--- a/kubernetes-ingress/templates/namespace.yaml
+++ b/kubernetes-ingress/templates/namespace.yaml
@@ -25,4 +25,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-weight": "-1"
 {{- end -}}


### PR DESCRIPTION
This pull request introduces an annotation "helm.sh/hook": "pre-install" to the namespace creation manifest in the haproxy-ingress chart. This change ensures that the namespace is created before any resources, including dependencies, are installed. This is particularly useful for users who want to manage namespaces and their associated resources using Helm, especially when they require specific annotations to be set on the namespace before deploying other resources.

Changes:

Added a namespace.yaml file in the templates directory with the necessary annotation.
Updated documentation to reflect the new annotation and its purpose.
Testing:

The change has been tested locally with the following setup:

Created a chart parent that includes haproxy-ingress as a dependency.
Confirmed that the namespace is created with the correct annotation before the installation of other resources.
Motivation:

This addition solves the issue where namespaces need to be pre-configured with specific annotations, ensuring compatibility with Helm's resource lifecycle. It provides a more seamless and automated experience for users managing complex deployments.