### PR TITLE
Add possibility to set crdjob annotations

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -41,9 +41,16 @@ spec:
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
+      {{- $podAnnotations := dict }}
+      {{- if .Values.crdjob.podAnnotations }}
+        {{- $podAnnotations = merge $podAnnotations .Values.crdjob.podAnnotations }}
+      {{- end }}
       {{- if .Values.controller.podAnnotations }}
+        {{- $podAnnotations = merge $podAnnotations .Values.controller.podAnnotations }}
+      {{- end }}
+      {{- if not (empty $podAnnotations) }}
       annotations:
-{{ toYaml .Values.controller.podAnnotations | indent 8 }}
+{{ toYaml $podAnnotations | indent 8 }}
       {{- end }}
     spec:
       restartPolicy: Never

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -590,3 +590,12 @@ controller:
     proxyParams:                                        # Mandatory if source is 'proxy'
       replicaCount: 3                                   # number of replicas of the proxy, mandatory if source is 'proxy'
       proxySvcLabelSelector: run:haproxy-ingress-proxy  # label selector of the proxy service, mandatory if source is 'proxy'
+
+## CRD job default values
+crdjob:
+  ## Additional annotations to add to the pod container metadata
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ## All annotations from the controller (if set) are added to the pod metadata
+  ## If the annotation key is set for both controller and crdjob, the crdjob annotation will be used
+  podAnnotations: {}
+  #  key: value


### PR DESCRIPTION
**Adding possibility to set annotations on the crdjob**

**_Motivation:_**

On our clusters we run a service mesh (linkerd)

The linkerd sidecar container (linkerd-proxy) gets auto-injected into any pod in the namespace we deploy haproxy into.

For k8s jobs there is a known limitation (see: https://github.com/linkerd/linkerd2/issues/1869) with sidecar containers as the sidecar container will not be shut down automatically when the job finishes.

This leaves us with the `haproxy-ingress-internal-kubernetes-ingress-crdjob-xx` pod hanging around in the cluster until it gets manually deleted because the linkerd-proxy container in the pod is not being terminated.

Solution:
 - Allow annotations to be set on the job spec (we can then set linkerd.io/inject: disabled for the job only, as for the controller we want linkerd to be enabled - so we cannot use Values.controller.podAnnotations)
 
 Merging:
 - If an annotation is only set for the controller, it will (just like before) also be added to the crdjob.
 - If an annotation is only set for the crdjob it will only be added to the crdjob.
 - If an annotation is set for both, the value for the controller will be added to the controller and the value for the crdjob will be added to the crdjob.