### PR TITLE
Add option to enable checksum/config annotation in controller

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -51,8 +51,11 @@ spec:
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
-      {{- if .Values.controller.podAnnotations }}
       annotations:
+      {{- if .Values.controller.checksumConfigMap.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -50,8 +50,11 @@ spec:
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
-      {{- if .Values.controller.podAnnotations }}
       annotations:
+      {{- if .Values.controller.checksumConfigMap.enabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -331,6 +331,11 @@ controller:
   #  - --disable-quic
   #  - --sync-period=10s
 
+  ## Automatically Roll Deployments
+  # ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+  checksumConfigMap:
+    enabled: false
+
   ## Custom configuration for Controller
   ## ref: https://github.com/haproxytech/kubernetes-ingress/tree/master/documentation
   config: {}


### PR DESCRIPTION
While haproxy is capable of reloading the configuration without restarting the pod, which is great, for some use cases it's still easier to restart the pod and have an immediate feedback if it can't restart because the configuration is wrong.