### PR TITLE
BUG:  kubernetes-ingress: Fix controller.podAnnotations not being templatable in every location

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -48,7 +48,11 @@ spec:
         {{- $podAnnotations = merge $podAnnotations .Values.crdjob.podAnnotations }}
       {{- end }}
       {{- if .Values.controller.podAnnotations }}
-        {{- $podAnnotations = merge $podAnnotations .Values.controller.podAnnotations }}
+        {{- if eq "string" (printf "%T" .Values.controller.podAnnotations) }}
+          {{- $podAnnotations = merge $podAnnotations (tpl .Values.controller.podAnnotations . | fromYaml) }}
+        {{- else }}
+          {{- $podAnnotations = merge $podAnnotations .Values.controller.podAnnotations }}
+        {{- end }}
       {{- end }}
       {{- if not (empty $podAnnotations) }}
       annotations:

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -53,7 +53,11 @@ spec:
         {{- end }}
       {{- if .Values.controller.podAnnotations }}
       annotations:
+{{- if eq "string" (printf "%T" .Values.controller.podAnnotations) }}
+{{ tpl .Values.controller.podAnnotations . | indent 8 }}
+{{- else }}
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
+{{- end }}
       {{- end }}
     spec:
       enableServiceLinks: {{ .Values.controller.enableServiceLinks }}

--- a/kubernetes-ingress/templates/controller-proxy-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-proxy-deployment.yaml
@@ -52,7 +52,11 @@ spec:
         {{- end }}
       {{- if .Values.controller.podAnnotations }}
       annotations:
+{{- if eq "string" (printf "%T" .Values.controller.podAnnotations) }}
+{{ tpl .Values.controller.podAnnotations . | indent 8 }}
+{{- else }}
 {{ toYaml .Values.controller.podAnnotations | indent 8 }}
+{{- end }}
       {{- end }}
     spec:
       enableServiceLinks: {{ .Values.controller.enableServiceLinks }}


### PR DESCRIPTION
Fix a bug introduced in #276 where controller.podAnnotations was not templatable in every place it was used. This is now fixed.