### PR TITLE
feat(haproxy): Add deployment annotations as a configurable property.

### DIFF
--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -22,6 +22,10 @@ metadata:
   namespace: {{ include "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.deploymentAnnotations }}
+{{ tpl (toYaml .Values.deploymentAnnotations) . | indent 4 }}
+    {{- end }}
 spec:
   minReadySeconds: {{ .Values.minReadySeconds }}
   {{- if and (not .Values.autoscaling.enabled) (not .Values.keda.enabled) }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -96,6 +96,11 @@ args:
   defaults: ["-f", "/usr/local/etc/haproxy/haproxy.cfg"]
   extraArgs: []    # EE images require disabling this due to S6-overlay
 
+## Annotations to add to the deployment metadata
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+deploymentAnnotations: {}
+#  key: value
+
 ## Controller Container liveness/readiness probe configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:


### PR DESCRIPTION
This feature adds the ability for users to configure annotations on the deployment configuration. This is useful for certain integrations such as Reloader that watches for changes to associated resources.

Example usage:
```yaml
# values.yaml

deploymentAnnotations:
  reloader.stakater.com/auto: "true"
```