### PR TITLE
kubernetes-ingress: bind only defined ports as HostPort

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -153,8 +153,8 @@ spec:
             - name: {{ $key }}
               containerPort: {{ $value }}
               protocol: TCP
-              {{- if $useHostPort }}
-              hostPort: {{ index $hostPorts $key | default $value }}
+              {{- if and $useHostPort (index $hostPorts $key) }}
+              hostPort: {{ index $hostPorts $key }}
               {{- end }}
               {{- if $hostIP }}
               hostIP: {{ $hostIP }}


### PR DESCRIPTION
This PR improves the port configuration options for the HAProxy chart, allowing for more granular control over containerPorts and hostPorts.

We should be able, when using hostPort, to define part of ports to be containerPorts without making it **always** hostPort as well (as it is currently).

 (I.e - we want to bind 80 and 443 from host, and have stats page accessible through service)
 Thanks to this change, only ports that are explicitly defined as hostPorts will be bind and accessible publicly.

* In my case, the thing is about stat on port 1024. I want it only accessible from inside the cluster.
Also, stat is set as hostPort by default in [values.yaml ](https://github.com/haproxytech/helm-charts/blob/e3b0b23581fb9abda695c19376f3e22ce65007dd/kubernetes-ingress/values.yaml#L499), but after this change is merged, it can be overwritten to be empty in user's values.yaml and it will work as expected.
* It is already configured to work like that in haproxy helmchart, merged in this [PR
](https://github.com/haproxytech/helm-charts/pull/208)