### PR TITLE
MINOR: Use templates for labels to remove duplication

### DIFF
--- a/kubernetes-ingress/templates/_helpers.tpl
+++ b/kubernetes-ingress/templates/_helpers.tpl
@@ -58,6 +58,65 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create HAProxy Ingress Chart labels
+*/}}
+{{- define "kubernetes-ingress.helmChartLabels" -}}
+helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Create HAProxy Ingress Selector labels
+*/}}
+{{- define "kubernetes-ingress.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create HAProxy Ingress labels
+*/}}
+{{- define "kubernetes-ingress.labels" -}}
+{{ include "kubernetes-ingress.selectorLabels" . }}
+{{ include "kubernetes-ingress.helmChartLabels" . }}
+{{- end }}
+
+{{/*
+Create CRD Job selector labels
+*/}}
+{{- define "kubernetes-ingress.crdJobSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create CRD Job labels
+*/}}
+{{- define "kubernetes-ingress.crdJobLabels" -}}
+{{ include "kubernetes-ingress.crdJobSelectorLabels" . }}
+{{ include "kubernetes-ingress.helmChartLabels" . }}
+{{- end }}
+
+{{/*
+Create Service Proxy selector labels
+*/}}
+{{- define "kubernetes-ingress.serviceProxySelectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create Service Proxy labels
+*/}}
+{{- define "kubernetes-ingress.serviceProxyLabels" -}}
+{{ include "kubernetes-ingress.serviceProxySelectorLabels" . }}
+{{ include "kubernetes-ingress.helmChartLabels" . }}
+{{- end }}
+
+{{/*
 Encode an imagePullSecret string.
 */}}
 {{- define "kubernetes-ingress.imagePullSecret" }}

--- a/kubernetes-ingress/templates/clusterrole.yaml
+++ b/kubernetes-ingress/templates/clusterrole.yaml
@@ -20,11 +20,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/kubernetes-ingress/templates/clusterrolebinding.yaml
+++ b/kubernetes-ingress/templates/clusterrolebinding.yaml
@@ -20,11 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes-ingress/templates/controller-configmap.yaml
+++ b/kubernetes-ingress/templates/controller-configmap.yaml
@@ -20,11 +20,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.configAnnotations }}
   annotations:
 {{ toYaml .Values.controller.configAnnotations | indent 4 }}

--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -20,11 +20,7 @@ metadata:
   name: {{ include "kubernetes-ingress.crdjob.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.crdjob.fullname" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.crdJobLabels" . | nindent 4 }}
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
@@ -38,8 +34,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "kubernetes-ingress.crdjob.fullname" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "kubernetes-ingress.crdJobSelectorLabels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -25,11 +25,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
     {{- if .Values.controller.extraLabels }}
 {{ toYaml .Values.controller.extraLabels | indent 4 }}
     {{- end }}
@@ -41,13 +37,11 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "kubernetes-ingress.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "kubernetes-ingress.selectorLabels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}

--- a/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
+++ b/kubernetes-ingress/templates/controller-defaultcertsecret.yaml
@@ -23,11 +23,7 @@ metadata:
   name: {{ include "kubernetes-ingress.defaultTLSSecret.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
     {{- if .Values.controller.extraLabels }}
 {{ toYaml .Values.controller.extraLabels | indent 4 }}
     {{- end }}
@@ -36,8 +32,7 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "kubernetes-ingress.selectorLabels" . | nindent 6 }}
   {{- with .Values.controller.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -45,8 +40,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "kubernetes-ingress.selectorLabels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}

--- a/kubernetes-ingress/templates/controller-hpa.yaml
+++ b/kubernetes-ingress/templates/controller-hpa.yaml
@@ -32,11 +32,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/kubernetes-ingress/templates/controller-ingressclass.yaml
+++ b/kubernetes-ingress/templates/controller-ingressclass.yaml
@@ -24,11 +24,7 @@ kind: IngressClass
 metadata:
   name: {{ .Values.controller.ingressClassResource.name }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.ingressClassResource.default }}
   annotations:
     ingressclass.kubernetes.io/is-default-class: "true"

--- a/kubernetes-ingress/templates/controller-keda.yaml
+++ b/kubernetes-ingress/templates/controller-keda.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
   {{- if .Values.controller.keda.scaledObject.annotations }}
   annotations: {{ toYaml .Values.controller.keda.scaledObject.annotations | nindent 4 }}
   {{- end }}

--- a/kubernetes-ingress/templates/controller-poddisruptionbudget.yaml
+++ b/kubernetes-ingress/templates/controller-poddisruptionbudget.yaml
@@ -25,11 +25,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 spec:
   {{- if .Values.controller.PodDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.controller.PodDisruptionBudget.maxUnavailable }}
@@ -39,6 +35,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "kubernetes-ingress.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-podmonitor.yaml
+++ b/kubernetes-ingress/templates/controller-podmonitor.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.podMonitorName" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
     {{- if .Values.controller.podMonitor.extraLabels }}
     {{ toYaml .Values.controller.podMonitor.extraLabels | nindent 4 }}
     {{- end }}
@@ -37,6 +33,5 @@ spec:
     - {{ include "kubernetes-ingress.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "kubernetes-ingress.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-podsecuritypolicy.yaml
+++ b/kubernetes-ingress/templates/controller-podsecuritypolicy.yaml
@@ -31,11 +31,7 @@ metadata:
 {{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
 {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
   name: {{ include "kubernetes-ingress.fullname" . }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'

--- a/kubernetes-ingress/templates/controller-proxy-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-proxy-deployment.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.serviceProxyName" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.serviceProxyLabels" . | nindent 4 }}
     {{- if .Values.controller.extraLabels }}
 {{ toYaml .Values.controller.extraLabels | indent 4 }}
     {{- end }}
@@ -36,8 +32,7 @@ spec:
   minReadySeconds: {{ .Values.controller.minReadySeconds }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "kubernetes-ingress.serviceProxySelectorLabels" . | nindent 6 }}
   {{- with .Values.controller.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -45,8 +40,7 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "kubernetes-ingress.serviceProxySelectorLabels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
 {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}

--- a/kubernetes-ingress/templates/controller-proxy-service.yaml
+++ b/kubernetes-ingress/templates/controller-proxy-service.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.serviceProxyName" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.serviceProxyLabels" . | nindent 4 }}
     {{ (split ":" .Values.controller.sync.proxyParams.proxySvcLabelSelector)._0 }}: {{ (split ":" .Values.controller.sync.proxyParams.proxySvcLabelSelector)._1 }}
 {{- if .Values.controller.service.labels }}
 {{ toYaml .Values.controller.service.labels | indent 4 }}
@@ -65,8 +61,7 @@ spec:
     {{- end }}
   {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.serviceProxyName" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "kubernetes-ingress.serviceProxySelectorLabels" . | nindent 4 }}
   {{- if .Values.controller.service.sessionAffinity }}
   sessionAffinity: {{ .Values.controller.service.sessionAffinity }}
   {{- end }}

--- a/kubernetes-ingress/templates/controller-pullsecret.yaml
+++ b/kubernetes-ingress/templates/controller-pullsecret.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ include "kubernetes-ingress.imagePullSecret" . }}

--- a/kubernetes-ingress/templates/controller-role.yaml
+++ b/kubernetes-ingress/templates/controller-role.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 rules:
 - apiGroups: 
   - "policy"

--- a/kubernetes-ingress/templates/controller-rolebinding.yaml
+++ b/kubernetes-ingress/templates/controller-rolebinding.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/kubernetes-ingress/templates/controller-service-metrics.yaml
+++ b/kubernetes-ingress/templates/controller-service-metrics.yaml
@@ -35,11 +35,7 @@ metadata:
   name: {{ include "kubernetes-ingress.serviceMetricsName" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.service.metrics.labels }}
 {{ toYaml .Values.controller.service.metrics.labels | indent 4 }}
 {{- end }}
@@ -58,6 +54,5 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.stat }}
     {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "kubernetes-ingress.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.fullname" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 {{- if .Values.controller.service.labels }}
 {{ toYaml .Values.controller.service.labels | indent 4 }}
 {{- end }}
@@ -107,8 +103,7 @@ spec:
     {{- end }}
   {{- end }}
   selector:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "kubernetes-ingress.selectorLabels" . | nindent 4 }}
   {{- if .Values.controller.service.sessionAffinity }}
   sessionAffinity: {{ .Values.controller.service.sessionAffinity }}
   {{- end }}

--- a/kubernetes-ingress/templates/controller-serviceaccount.yaml
+++ b/kubernetes-ingress/templates/controller-serviceaccount.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.serviceAccountName" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
 {{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-servicemonitor.yaml
+++ b/kubernetes-ingress/templates/controller-servicemonitor.yaml
@@ -21,11 +21,7 @@ metadata:
   name: {{ include "kubernetes-ingress.serviceMonitorName" . }}
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
     {{- if .Values.controller.serviceMonitor.extraLabels }}
     {{ toYaml .Values.controller.serviceMonitor.extraLabels | nindent 4 }}
     {{- end }}
@@ -37,6 +33,5 @@ spec:
     - {{ include "kubernetes-ingress.namespace" . }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "kubernetes-ingress.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/kubernetes-ingress/templates/namespace.yaml
+++ b/kubernetes-ingress/templates/namespace.yaml
@@ -20,11 +20,7 @@ kind: Namespace
 metadata:
   name: {{ include "kubernetes-ingress.namespace" . }}
   labels:
-    app.kubernetes.io/name: {{ include "kubernetes-ingress.name" . }}
-    helm.sh/chart: {{ include "kubernetes-ingress.chart" . }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    {{- include "kubernetes-ingress.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "-1"


### PR DESCRIPTION
This refactor replaces duplicated label definitions with reusable templates, improving maintainability and reducing redundancy in the Helm chart.