### PR TITLE
MINOR: kubernetes-ingress remove port name prometheus from service

### DIFF
--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -84,15 +84,6 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.stat }}
     {{- end }}
   {{- end }}
-  {{- if .Values.controller.service.enablePorts.prometheus }}
-    - name: prometheus
-      port: {{ .Values.controller.service.ports.prometheus }}
-      protocol: TCP
-      targetPort: {{ .Values.controller.service.targetPorts.prometheus }}
-    {{- if .Values.controller.service.nodePorts.prometheus }}
-      nodePort: {{ .Values.controller.service.nodePorts.prometheus }}
-    {{- end }}
-  {{- end }}
   {{- range .Values.controller.service.tcpPorts }}
     - name: {{ .name | trunc 15 | trimSuffix "-" }}
       port: {{ .port }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -409,7 +409,6 @@ controller:
       http: 80
       https: 443
       stat: 1024
-      prometheus: 6060
 
     ## The controller service ports for http, https and stat can be disabled by
     ## setting below to false - this could be useful when only deploying haproxy
@@ -429,7 +428,6 @@ controller:
       https: https
       quic: quic
       stat: stat
-      prometheus: prometheus
 
     ## Additional tcp ports to expose
     ## This is especially useful for TCP services:


### PR DESCRIPTION
This port was confusing as accessing the ingress controller metrics is done on the /metrics but on port http