### PR TITLE
MINOR: kubernetes-ingress add service port named admin

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -120,8 +120,9 @@ spec:
 {{- if .Values.controller.logging.level }}
           - --log={{ .Values.controller.logging.level }}
 {{- end }}
-{{- if .Values.controller.service.enablePorts.prometheus }}
+{{- if .Values.controller.service.enablePorts.admin }}
           - --prometheus
+          - --pprof
 {{- end }}
 {{- range .Values.controller.extraArgs }}
           - {{ . }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -120,8 +120,9 @@ spec:
 {{- if .Values.controller.logging.level }}
           - --log={{ .Values.controller.logging.level }}
 {{- end }}
-{{- if .Values.controller.service.enablePorts.prometheus }}
+{{- if .Values.controller.service.enablePorts.admin }}
           - --prometheus
+          - --pprof
 {{- end }}
 {{- if eq .Values.controller.sync.mode "fetch" }}
   {{- if .Values.controller.sync.fetchParams.period }}

--- a/kubernetes-ingress/templates/controller-proxy-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-proxy-deployment.yaml
@@ -120,8 +120,9 @@ spec:
 {{- if .Values.controller.logging.level }}
           - --log={{ .Values.controller.logging.level }}
 {{- end }}
-{{- if .Values.controller.service.enablePorts.prometheus }}
+{{- if .Values.controller.service.enablePorts.admin }}
           - --prometheus
+          - --pprof
 {{- end }}
           - --proxy-server-mode
           - --k8s-api-sync-type=k8s

--- a/kubernetes-ingress/templates/controller-service.yaml
+++ b/kubernetes-ingress/templates/controller-service.yaml
@@ -84,6 +84,15 @@ spec:
       nodePort: {{ .Values.controller.service.nodePorts.stat }}
     {{- end }}
   {{- end }}
+  {{- if .Values.controller.service.enablePorts.admin }}
+    - name: admin
+      port: {{ .Values.controller.service.ports.admin }}
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.admin }}
+    {{- if .Values.controller.service.nodePorts.admin }}
+      nodePort: {{ .Values.controller.service.nodePorts.admin }}
+    {{- end }}
+  {{- end }}
   {{- range .Values.controller.service.tcpPorts }}
     - name: {{ .name | trunc 15 | trimSuffix "-" }}
       port: {{ .port }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -121,6 +121,7 @@ controller:
     http: 8080
     https: 8443
     stat: 1024
+    admin: 6060
 
   ## Controller Container liveness/readiness probe configuration
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -401,6 +402,7 @@ controller:
     #  http: 31080
     #  https: 31443
     #  stat: 31024
+    #  admin: 31060
 
     ## Service ports to use for http, https and stat
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -408,6 +410,7 @@ controller:
       http: 80
       https: 443
       stat: 1024
+      admin: 6060
 
     ## The controller service ports for http, https and stat can be disabled by
     ## setting below to false - this could be useful when only deploying haproxy
@@ -418,7 +421,7 @@ controller:
       https: true
       quic: true
       stat: true
-      prometheus: true
+      admin: true
 
     ## Target port mappings for http, https and stat
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -427,6 +430,7 @@ controller:
       https: https
       quic: quic
       stat: stat
+      admin: admin
 
     ## Additional tcp ports to expose
     ## This is especially useful for TCP services:


### PR DESCRIPTION
    Re-adding the kubernetes-ingress service port that was named prometheus but rename it as admin as it exposes KIC metrics and pprof.
    To sum up:
    Exposed on kubernetes-ingress service port named 'admin':
    - KIC Prometheus metrics under: /metrics
    - Pprof under: /debug/pprof Exposed on kubernetes-ingress service port named 'stat':
    - HAProxy Prometheus metrics under: /metrics