### PR TITLE
Ingress Controller: update appVersion to 3.1.8

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -17,7 +17,7 @@ name: kubernetes-ingress
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 type: application
 version: 1.44.4
-appVersion: 3.1.7
+appVersion: 3.1.8
 kubeVersion: ">=1.23.0-0"
 keywords:
   - ingress
@@ -31,7 +31,5 @@ maintainers:
     email: dkorunic@haproxy.com
 engine: gotpl
 annotations:
-  artifacthub.io/changes: |
-    - Use Ingress Controller 3.1.7 version for base image
-    - Add service port named admin (#294)
-    - Don't merge controller podAnnotations with crdjob podAnnotations (#293)
+  artifacthub.io/changes: |-
+    - Use Ingress Controller 3.1.8 version for base image


### PR DESCRIPTION
This automatic PR updates the appVersion for Ingress controller in Chart.yaml to 3.1.8.