### PR TITLE
feat: add support for deployment labels, raw container and service additional ports

### DIFF
--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -121,6 +121,9 @@ spec:
               hostPort: {{ index $hostPorts $key }}
               {{- end }}
           {{- end }}
+          {{- with .Values.rawContainerPorts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | trim | nindent 12 }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -22,6 +22,9 @@ metadata:
   namespace: {{ include "haproxy.namespace" . }}
   labels:
     {{- include "haproxy.labels" . | nindent 4 }}
+    {{- if .Values.deploymentLabels }}
+{{ tpl (toYaml .Values.deploymentLabels) . | indent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.deploymentAnnotations }}
 {{ tpl (toYaml .Values.deploymentAnnotations) . | indent 4 }}
@@ -122,6 +125,9 @@ spec:
             - name: {{ $key }}
               containerPort: {{ $value }}
               protocol: TCP
+          {{- end }}
+          {{- with .Values.rawContainerPorts }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:

--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -52,7 +52,7 @@ spec:
   externalIPs:
   {{- toYaml . | nindent 2 }}
   {{- end }}
-  {{- if or .Values.containerPorts .Values.service.additionalPorts }}
+  {{- if or .Values.containerPorts .Values.service.additionalPorts .Values.service.rawAdditionalPorts }}
   {{- $nodePorts := .Values.service.nodePorts }}
   {{- $servicePortType := .Values.service.type }}
   ports:
@@ -77,5 +77,8 @@ spec:
     nodePort: {{ get $nodePorts $key }}
   {{- end }}
   {{- end }}
+  {{- end }}
+  {{- with .Values.service.rawAdditionalPorts }}
+  {{- toYaml . | nindent 2 }}
   {{- end }}
   {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -101,6 +101,9 @@ args:
 deploymentAnnotations: {}
 #  key: value
 
+deploymentLabels: {}
+#  key: value
+
 ## Controller Container liveness/readiness probe configuration
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
@@ -173,6 +176,18 @@ containerPorts:   # has to match hostPorts when useHostNetwork is true
   http: 80
   https: 443
   stat: 1024
+
+## Raw container ports configuration (alternative to containerPorts for more control)
+## Allows specifying container ports in full Kubernetes format with custom protocols, names, etc.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#containerport-v1-core
+rawContainerPorts: []
+# Example:
+# - containerPort: 9090
+#   name: metrics-port
+#   protocol: TCP
+# - containerPort: 8080
+#   name: custom-http
+#   protocol: TCP
 
 ## Deployment strategy definition
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
@@ -499,6 +514,20 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
   additionalPorts: {}
     # prometheus: 9101
+
+  ## Raw additional service ports configuration (alternative to additionalPorts for more control)
+  ## Allows specifying service ports in full Kubernetes format with custom protocols, names, etc.
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#serviceport-v1-core
+  rawAdditionalPorts: []
+  # Example:
+  # - name: metrics-port
+  #   port: 9090
+  #   targetPort: 9090
+  #   protocol: TCP
+  # - name: custom-service
+  #   port: 8080
+  #   targetPort: custom-http
+  #   protocol: TCP
 
   ## NodePort custom port
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport-custom-port


### PR DESCRIPTION
This pull request introduces enhanced flexibility for configuring ports and metadata in the HAProxy Helm chart's Kubernetes manifests. The main improvements are the addition of "raw" configuration options for container and service ports, and the ability to specify custom deployment labels. These changes allow users to define ports and labels with greater detail and control, supporting advanced scenarios.

**Port configuration enhancements:**

* Added support for `rawContainerPorts` in `values.yaml`, allowing users to specify container ports in full Kubernetes format (including custom protocols and names). This is now rendered in both `daemonset.yaml` and `deployment.yaml` templates. [[1]](diffhunk://#diff-dbc40bde5663305c8fdb5dd4eb23c673678ed5317da173913d6fe4ac4b75bf07R180-R191) [[2]](diffhunk://#diff-102a252dcdf0814d42f14083d94d3510222d668f595dfe13a76b1ac47dbb8504R124-R126) [[3]](diffhunk://#diff-9f7a179180032c2ccd9c567857a98bd63fac4535dc7c4e5707fda97c1bfbbcafR129-R131)
* Added support for `service.rawAdditionalPorts` in `values.yaml`, enabling detailed specification of additional service ports. The `service.yaml` template now renders these ports when provided. [[1]](diffhunk://#diff-dbc40bde5663305c8fdb5dd4eb23c673678ed5317da173913d6fe4ac4b75bf07R518-R531) [[2]](diffhunk://#diff-3a30a697dc61d7ccf811f36ce904f0eed6ed8c03b5a7859b814fed386904edb8L55-R55) [[3]](diffhunk://#diff-3a30a697dc61d7ccf811f36ce904f0eed6ed8c03b5a7859b814fed386904edb8R81-R83)

**Metadata configuration enhancements:**

* Introduced `deploymentLabels` in `values.yaml` and updated `deployment.yaml` to render these labels, allowing users to add custom labels to the deployment metadata. [[1]](diffhunk://#diff-dbc40bde5663305c8fdb5dd4eb23c673678ed5317da173913d6fe4ac4b75bf07R104-R106) [[2]](diffhunk://#diff-9f7a179180032c2ccd9c567857a98bd63fac4535dc7c4e5707fda97c1bfbbcafR25-R27)…ditional ports config