### PR TITLE
MINOR: add fallback configuration for KEDA

### DIFF
--- a/haproxy/templates/keda.yaml
+++ b/haproxy/templates/keda.yaml
@@ -38,6 +38,10 @@ spec:
 {{- with .Values.keda.triggers }}
 {{ toYaml . | indent 2 }}
 {{ end }}
+{{- with .Values.keda.fallback }}
+  fallback:
+{{ toYaml . | indent 4 }}
+{{- end }}
   advanced:
     restoreToOriginalReplicaCount: {{ .Values.keda.restoreToOriginalReplicaCount }}
 {{- if .Values.keda.behavior }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -448,6 +448,10 @@ keda:
   pollingInterval: 30
   cooldownPeriod: 300
   restoreToOriginalReplicaCount: false
+  # fallback:
+  #   failureThreshold: 3
+  #   replicas: 6
+  #   behavior: static
   scaledObject:
     annotations: {}
   behavior: {}

--- a/kubernetes-ingress/templates/controller-keda.yaml
+++ b/kubernetes-ingress/templates/controller-keda.yaml
@@ -36,6 +36,10 @@ spec:
 {{- with .Values.controller.keda.triggers }}
 {{ toYaml . | indent 2 }}
 {{ end }}
+{{- with .Values.controller.keda.fallback }}
+  fallback:
+{{ toYaml . | indent 4 }}
+{{- end }}
   advanced:
     restoreToOriginalReplicaCount: {{ .Values.controller.keda.restoreToOriginalReplicaCount }}
 {{- if .Values.controller.keda.horizontalPodAutoscalerConfig }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -266,6 +266,10 @@ controller:
     pollingInterval: 30
     cooldownPeriod: 300
     restoreToOriginalReplicaCount: false
+    # fallback:
+    #   failureThreshold: 3
+    #   replicas: 6
+    #   behavior: static
     scaledObject:
       annotations: {}
     horizontalPodAutoscalerConfig: {}


### PR DESCRIPTION
This pull request is adding support for configuring a fallback for the KEDA ScaledObject based upon the [documentation](https://keda.sh/docs/2.17/reference/scaledobject-spec/#fallback).