### PR TITLE
feat(haproxy): allow setting ipFamilies and ipFamilyPolicy of Service for dual stack

### DIFF
--- a/haproxy/ci/daemonset-ipfamily-values.yaml
+++ b/haproxy/ci/daemonset-ipfamily-values.yaml
@@ -1,0 +1,4 @@
+kind: DaemonSet
+service:
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack

--- a/haproxy/ci/deployment-ipfamily-values.yaml
+++ b/haproxy/ci/deployment-ipfamily-values.yaml
@@ -1,0 +1,4 @@
+kind: Deployment
+service:
+  ipFamilies: [IPv4]
+  ipFamilyPolicy: SingleStack

--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -48,6 +48,13 @@ spec:
   loadBalancerSourceRanges:
   {{- toYaml . | nindent 2 }}
   {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies:
+  {{- toYaml .Values.service.ipFamilies | nindent 2 }}
+  {{- end }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy | quote }}
+  {{- end }}
   {{- with .Values.service.externalIPs }}
   externalIPs:
   {{- toYaml . | nindent 2 }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -511,6 +511,12 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   labels: {}
 
+  ## IPv4/IPv6 dual-stack
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
+  ##
+  # ipFamilies: [IPv4, IPv6]
+  # ipFamilyPolicy: PreferDualStack
+
   ## Service externalTrafficPolicy
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy
   # externalTrafficPolicy: Cluster


### PR DESCRIPTION
Slightly adapted copy/paste from in ingress chart. Would be nice to have this feature in the haproxy chart as well to be able to route dual stack traffic.