### PR TITLE
Ingress Controller: update appVersion to 3.1.13

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -17,7 +17,7 @@ name: kubernetes-ingress
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 type: application
 version: 1.45.0
-appVersion: 3.1.12
+appVersion: 3.1.13
 kubeVersion: ">=1.23.0-0"
 keywords:
   - ingress
@@ -32,7 +32,4 @@ maintainers:
 engine: gotpl
 annotations:
   artifacthub.io/changes: |-
-    - Use Ingress Controller 3.1.12 version for base image
-    - Allow creating metrics service if controller service is not LoadBalancer (#306)
-    - Add fallback configuration for KEDA (#304)
-    - Add option to configure 'metadata.annotations' for deployment and daemonset (#302)
+    - Use Ingress Controller 3.1.13 version for base image


### PR DESCRIPTION
This automatic PR updates the appVersion for Ingress controller in Chart.yaml to 3.1.13.