### PR TITLE
Make initContainers templateable

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -276,9 +276,13 @@ spec:
         {{- else if gt (len .Values.controller.extraVolumes) 0 }}
 {{ toYaml .Values.controller.extraVolumes | indent 8 }}
         {{- end }}
-      {{- with.Values.controller.initContainers }}
+      {{- if .Values.controller.initContainers }}
       initContainers:
-          {{- toYaml . | nindent 8 }}
+        {{- if eq "string" (printf "%T" .Values.controller.initContainers) }}
+{{ tpl .Values.controller.initContainers . | indent 8 }}
+        {{- else }}
+{{ toYaml .Values.controller.initContainers | indent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -269,9 +269,13 @@ spec:
         {{- else if gt (len .Values.controller.extraVolumes) 0 }}
 {{ toYaml .Values.controller.extraVolumes | indent 8 }}
         {{- end }}
-      {{- with.Values.controller.initContainers }}
+      {{- if .Values.controller.initContainers }}
       initContainers:
-          {{- toYaml . | nindent 8 }}
+        {{- if eq "string" (printf "%T" .Values.controller.initContainers) }}
+{{ tpl .Values.controller.initContainers . | indent 8 }}
+        {{- else }}
+{{ toYaml .Values.controller.initContainers | indent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:

--- a/kubernetes-ingress/templates/controller-proxy-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-proxy-deployment.yaml
@@ -260,9 +260,13 @@ spec:
         {{- else if gt (len .Values.controller.extraVolumes) 0 }}
 {{ toYaml .Values.controller.extraVolumes | indent 8 }}
         {{- end }}
-      {{- with.Values.controller.initContainers }}
+      {{- if .Values.controller.initContainers }}
       initContainers:
-          {{- toYaml . | nindent 8 }}
+        {{- if eq "string" (printf "%T" .Values.controller.initContainers) }}
+{{ tpl .Values.controller.initContainers . | indent 8 }}
+        {{- else }}
+{{ toYaml .Values.controller.initContainers | indent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
It would be nice to have initContainers templatable, just like extraContainers, to use it for sidecars (this resolves #307). I tested it with ingress deployed as Deployment