### PR TITLE
Add helm hook annotations to crdjob

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -24,6 +24,8 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-delete-policy: "hook-succeeded"
   {{- with .Values.controller.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Hi, I have very similar issue to #214. Since crdjob has no helm hook annotations and it changes name on every upgrade, [helm-diff](https://github.com/databus23/helm-diff) always reports a difference making it hard to monitor drift for this chart for helm users (there is an option to ignore hook changes, but only to suppress output for certain kinds, not to ignore them completely).

There are helm hook annotations on other resources in this chart (namespace, cert secret) and there already are argocd hook annotations on crdjob, so I thought that it may be reasonable to add helm hook annotations on crdjob as well. Additionally it would block release on failing hook for helm users, which may be a good thing.

WDYT?