### PR TITLE
Fix crdjob helm hook annotation

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -24,7 +24,7 @@ metadata:
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
-    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook: "post-install,pre-upgrade"
     helm.sh/hook-delete-policy: "hook-succeeded"
   {{- with .Values.controller.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
This is a fix for https://github.com/haproxytech/helm-charts/pull/312#issuecomment-3401645823. This time I tested it on a fresh cluster (although I haven't tested a scenario with actual crd change). Sorry for the inconvenience. For argocd it's ok, since according to docs 'Sync' phase is running in parallel with regular manifests.