### PR TITLE
Define automountServiceAccountToken on Deployment and DaemonSet

### DIFF
--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -53,6 +53,9 @@ spec:
       shareProcessNamespace: true
       {{- end }}
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
+{{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- if $useHostNetwork }}
       hostNetwork: true

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
       shareProcessNamespace: true
       {{- end }}
       serviceAccountName: {{ include "haproxy.serviceAccountName" . }}
+{{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -60,6 +60,9 @@ spec:
     spec:
       enableServiceLinks: {{ .Values.controller.enableServiceLinks }}
       serviceAccountName: {{ include "kubernetes-ingress.serviceAccountName" . }}
+{{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
       {{- if $useHostNetwork }}
       hostNetwork: true

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -59,6 +59,9 @@ spec:
     spec:
       enableServiceLinks: {{ .Values.controller.enableServiceLinks }}
       serviceAccountName: {{ include "kubernetes-ingress.serviceAccountName" . }}
+{{- if hasKey .Values.serviceAccount "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds }}
 {{- with .Values.controller.topologySpreadConstraints }}
       topologySpreadConstraints:


### PR DESCRIPTION
In some case, automountServiceAccountToken can be set to false by default even if ServiceAccount defines it as true

By defining automountServiceAccountToken in the Deployment/DaemonSet, it will work in all case.