### PR TITLE
feat: add gateway api support with httproute resource

### DIFF
--- a/haproxy/templates/httproute.yaml
+++ b/haproxy/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "haproxy.fullname" . -}}
+{{- $svcPort := .Values.httpRoute.servicePort -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "haproxy.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- with .Values.httpRoute.parentRefs }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -599,3 +599,45 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - haproxy.domain.com
+
+# -- Expose the service via gateway-api HTTPRoute
+# Requires Gateway API resources and suitable controller installed within the cluster
+# (see: https://gateway-api.sigs.k8s.io/guides/)
+httpRoute:
+  # HTTPRoute enabled.
+  enabled: false
+  # HTTPRoute servicePort to route to
+  servicePort: 80
+  # HTTPRoute labels
+  labels: {}
+  # HTTPRoute annotations.
+  annotations: {}
+  # Which Gateways this Route is attached to.
+  parentRefs:
+  - name: gateway
+    sectionName: http
+    # namespace: default
+  # Hostnames matching HTTP header.
+  hostnames:
+  - chart-example.local
+  # List of rules and filters applied.
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       set:
+  #       - name: My-Overwrite-Header
+  #         value: this-is-the-only-value
+  #       remove:
+  #       - User-Agent
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /echo
+  #     headers:
+  #     - name: version
+  #       value: v2


### PR DESCRIPTION
Used the template and values that come with `helm create chart` to keep it inline with other charts with two small adaptions:

* added servicePort to the HTTPRoute values
* added labels to the HTTPRoute

Both to keep it functionally the same as the current ingress approach.

Output looks like this with it enabled:

```yaml
# Source: haproxy/templates/httproute.yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: release-name-haproxy
  labels:
    helm.sh/chart: haproxy-1.26.1
    app.kubernetes.io/name: haproxy
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "3.2.6"
    app.kubernetes.io/managed-by: Helm
spec:
  parentRefs:
    - name: gateway
      sectionName: http
  hostnames:
    - chart-example.local
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: /
      backendRefs:
        - name: release-name-haproxy
          port: 80
```