### PR TITLE
Ingress Controller: update appVersion to 3.2.2

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -17,7 +17,7 @@ name: kubernetes-ingress
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 type: application
 version: 1.47.0
-appVersion: 3.2.1
+appVersion: 3.2.2
 kubeVersion: ">=1.23.0-0"
 keywords:
   - ingress
@@ -32,5 +32,4 @@ maintainers:
 engine: gotpl
 annotations:
   artifacthub.io/changes: |-
-    - Use Ingress Controller 3.2.1 version for base image
-    - Better defaults for liveness, readiness and startup probes
+    - Use Ingress Controller 3.2.2 version for base image


### PR DESCRIPTION
This automatic PR updates the appVersion for Ingress controller in Chart.yaml to 3.2.2.