### PR TITLE
MINOR: kubernetes-ingress: dedicated resources key for crdjob

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -96,7 +96,7 @@ spec:
               type: RuntimeDefault
             {{- end }}
           resources:
-            {{- toYaml .Values.controller.resources | nindent 12 }}
+            {{- toYaml .Values.crdjob.resources | nindent 12 }}
           {{- end }}
       {{- with .Values.crdjob.nodeSelector }}
       nodeSelector:

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -655,3 +655,14 @@ crdjob:
   ## Node Affinity for pod-node scheduling constraints
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
+
+  ## Compute Resources for the CRD Job
+  ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+  resources:
+  #  limits:
+  #    cpu: 250m
+  #    memory: 400Mi
+    requests:
+      cpu: 250m
+      memory: 400Mi
+


### PR DESCRIPTION
Hi!

There's no reason  to allocate the same resources for the CRDjob as the controller. 

For instance in my case, we request almost 100% of a node for the controller. As by default the CRD job have the same CPU/MEM request, it forces the nodepool to spawn a new node which is not expected