### PR TITLE
Add securityContext.sysctls options

### DIFF
--- a/kubernetes-ingress/templates/controller-daemonset.yaml
+++ b/kubernetes-ingress/templates/controller-daemonset.yaml
@@ -85,16 +85,14 @@ spec:
 {{- if .Values.controller.runtimeClassName }}
       runtimeClassName: {{ .Values.controller.runtimeClassName }}
 {{- end }}
-{{- if .Values.controller.unprivileged }}
+{{- if or .Values.controller.unprivileged (gt (len (.Values.controller.sysctls | default dict)) 0) }}
       securityContext:
+{{- if .Values.controller.unprivileged }}
         runAsNonRoot: true
         runAsUser:  1000
         runAsGroup: 1000
-{{- if .Values.controller.allowPrivilegedPorts }}
-        sysctls:
-         - name: net.ipv4.ip_unprivileged_port_start
-           value: "0"
 {{- end }}
+{{ include "kubernetes-ingress.controller.sysctls" . | nindent 8 }}
 {{- end }}
       containers:
         - name: {{ include "kubernetes-ingress.name" . }}-{{ .Values.controller.name }}

--- a/kubernetes-ingress/templates/controller-deployment.yaml
+++ b/kubernetes-ingress/templates/controller-deployment.yaml
@@ -85,16 +85,14 @@ spec:
 {{- if .Values.controller.runtimeClassName }}
       runtimeClassName: {{ .Values.controller.runtimeClassName }}
 {{- end }}
-{{- if .Values.controller.unprivileged }}
+{{- if or .Values.controller.unprivileged (gt (len (.Values.controller.sysctls | default dict)) 0) }}
       securityContext:
+{{- if .Values.controller.unprivileged }}
         runAsNonRoot: true
         runAsUser:  1000
         runAsGroup: 1000
-{{- if .Values.controller.allowPrivilegedPorts }}
-        sysctls:
-         - name: net.ipv4.ip_unprivileged_port_start
-           value: "0"
 {{- end }}
+{{ include "kubernetes-ingress.controller.sysctls" . | nindent 8 }}
 {{- end }}
       containers:
         - name: {{ include "kubernetes-ingress.name" . }}-{{ .Values.controller.name }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -102,6 +102,13 @@ controller:
   #   securityContext:
   #     privileged: true
 
+  ## Pod sysctls (applies to Deployment/DaemonSet template)
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
+  ## Note: when unprivileged=true and allowPrivilegedPorts=true, the chart will also
+  ## set net.ipv4.ip_unprivileged_port_start=0 unless you override it here.
+  sysctls: { }
+  #   "net.core.somaxconn": "8192"
+
   ## Pod termination grace period
   ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   terminationGracePeriodSeconds: 60


### PR DESCRIPTION
This change enables additional securityContext.sysctls configuration to better tune the Linux TCP/IP stack for high connection concurrency and faster socket churn.

The implementation preserves the existing allowPrivilegedPorts behavior while allowing users to define additional sysctl options.