### PR TITLE
feat(kubernetes-ingress,crdjob): add option to disable

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.crdjob.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -110,3 +111,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end -}}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -638,6 +638,7 @@ controller:
 
 ## CRD job default values
 crdjob:
+  enabled: true
   ## Additional annotations to add to the pod container metadata
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}


### PR DESCRIPTION
When deploying the ingress controller more than once per cluster, it should be possible to disable the crdjob.