### PR TITLE
Ingress Controller: update appVersion to 3.2.6

### DIFF
--- a/kubernetes-ingress/Chart.yaml
+++ b/kubernetes-ingress/Chart.yaml
@@ -17,7 +17,7 @@ name: kubernetes-ingress
 description: A Helm chart for HAProxy Kubernetes Ingress Controller
 type: application
 version: 1.48.0
-appVersion: 3.2.5
+appVersion: 3.2.6
 kubeVersion: ">=1.23.0-0"
 keywords:
   - ingress
@@ -32,4 +32,4 @@ maintainers:
 engine: gotpl
 annotations:
   artifacthub.io/changes: |-
-    - Add securityContext.sysctls options (#337)
+    - Use Ingress Controller 3.2.6 version for base image


### PR DESCRIPTION
This automatic PR updates the appVersion for Ingress controller in Chart.yaml to 3.2.6.