### PR TITLE
Added comment line in extraArgs section for case-insensitive matching | dependent another PR

### DIFF
--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -343,6 +343,7 @@ controller:
   ## Additional command line arguments to pass to Controller
   ## ref: https://github.com/haproxytech/kubernetes-ingress/blob/master/documentation/controller.md
   extraArgs: []
+  #  - --case-insensitive-path-match
   #  - --namespace-whitelist=default
   #  - --namespace-whitelist=namespace1
   #  - --namespace-blacklist=namespace2


### PR DESCRIPTION
Added comment line in extraArgs for case-insensitive matching line options. It is added for just a specify for new case-insensitive option. 

This PR dependent to https://github.com/haproxytech/kubernetes-ingress/issues/794 PR!