### PR TITLE
HAProxy Unified Gateway: update appVersion to 1.0.2

### DIFF
--- a/haproxy-unified-gateway/Chart.yaml
+++ b/haproxy-unified-gateway/Chart.yaml
@@ -17,7 +17,7 @@ name: haproxy-unified-gateway
 description: A Helm chart for HAProxy Unified Gateway - Kubernetes Gateway API Controller
 type: application
 version: 1.0.1
-appVersion: 1.0.1
+appVersion: 1.0.2
 kubeVersion: ">=1.26.0-0"
 keywords:
   - haproxy
@@ -36,4 +36,4 @@ maintainers:
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |-
-    - Use HAProxy Unified Gateway 1.0.1 version for base image
+    - Use HAProxy Unified Gateway 1.0.2 version for base image


### PR DESCRIPTION
This automatic PR updates the appVersion for HAProxy Unified Gateway in Chart.yaml to 1.0.2.