### PR TITLE
MINOR: fix(kubernetes-ingress): prevent ServiceMonitor from scraping metrics twice

### DIFF
--- a/kubernetes-ingress/templates/controller-service-metrics.yaml
+++ b/kubernetes-ingress/templates/controller-service-metrics.yaml
@@ -34,6 +34,7 @@ metadata:
   namespace: {{ include "kubernetes-ingress.namespace" . }}
   labels:
     {{- include "kubernetes-ingress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
 {{- if .Values.controller.service.metrics.labels }}
 {{ toYaml .Values.controller.service.metrics.labels | indent 4 }}
 {{- end }}

--- a/kubernetes-ingress/templates/controller-servicemonitor.yaml
+++ b/kubernetes-ingress/templates/controller-servicemonitor.yaml
@@ -34,4 +34,5 @@ spec:
   selector:
     matchLabels:
       {{- include "kubernetes-ingress.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
 {{- end }}


### PR DESCRIPTION
## Problem

When `controller.serviceMonitor.enabled=true` and `controller.service.enabled=true`, the ServiceMonitor matches **both** the main controller service and the dedicated metrics service (`*-metrics`), because they share identical `selectorLabels`:

- `app.kubernetes.io/name`
- `app.kubernetes.io/instance`

This causes Prometheus to scrape the metrics endpoint **twice**, resulting in duplicate time series.

## Fix

- Add `app.kubernetes.io/component: metrics` label to the `controller-service-metrics` Service
- Add the same label to the ServiceMonitor `selector.matchLabels`

The main `controller-service` does not carry this label, so only the dedicated metrics service is selected.

## Testing

```bash
helm template test ./kubernetes-ingress \
  --set controller.service.enabled=true \
  --set controller.serviceMonitor.enabled=true \
  --api-versions monitoring.coreos.com/v1
```

Verify:
- `controller-service` (main): no `app.kubernetes.io/component` label
- `controller-service-metrics`: has `app.kubernetes.io/component: metrics`
- `ServiceMonitor.spec.selector.matchLabels`: includes `app.kubernetes.io/component: metrics`