### PR TITLE
Add optional trafficDistribution for Services in haproxy chart

### DIFF
--- a/haproxy/ci/daemonset-trafficdistribution-values.yaml
+++ b/haproxy/ci/daemonset-trafficdistribution-values.yaml
@@ -1,0 +1,3 @@
+kind: DaemonSet
+service:
+  trafficDistribution: PreferClose

--- a/haproxy/ci/deployment-trafficdistribution-values.yaml
+++ b/haproxy/ci/deployment-trafficdistribution-values.yaml
@@ -1,0 +1,3 @@
+kind: Deployment
+service:
+  trafficDistribution: PreferClose

--- a/haproxy/templates/service.yaml
+++ b/haproxy/templates/service.yaml
@@ -38,6 +38,9 @@ spec:
   {{- if .Values.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
   {{- end }}
+  {{- if and (semverCompare ">=1.31.0-0" .Capabilities.KubeVersion.Version) .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}
   {{- with .Values.service.clusterIP }}
   clusterIP: {{ . | quote}}
   {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -525,6 +525,11 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
   # internalTrafficPolicy: Cluster
 
+  ## Traffic distribution policy for the Service
+  ## ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution
+  ## Supported values depend on Kubernetes version; examples: "PreferSameZone", "PreferSameNode"
+  # trafficDistribution: ""
+
   ## Additional Service ports to use(e.g. port of side container haproxy exporter)
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
   additionalPorts: {}


### PR DESCRIPTION
That's basically the same as in https://github.com/haproxytech/helm-charts/pull/352 but for `haproxy` chart.
Our use case: we want to set `trafficDistribution: PreferSameNode` as we install haproxy as a Daemonset.
Ref: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution