### PR TITLE
haproxy: DaemonSet: allow overriding updateStrategy

### DIFF
--- a/haproxy/templates/daemonset.yaml
+++ b/haproxy/templates/daemonset.yaml
@@ -27,10 +27,10 @@ metadata:
     {{- include "haproxy.labels" . | nindent 4 }}
 spec:
   minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- with .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "haproxy.selectorLabels" . | nindent 6 }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -189,13 +189,20 @@ rawContainerPorts: []
 #   name: custom-http
 #   protocol: TCP
 
-## Deployment strategy definition
+## *Deployment* strategy definition
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 strategy: {}
 #  rollingUpdate:
 #    maxSurge: 25%
 #    maxUnavailable: 25%
 #  type: RollingUpdate
+
+## *DaemonSet* update strategy definition
+## ref: https://kubernetes.io/docs/reference/kubernetes-api/apps/daemon-set-v1/#DaemonSetUpdateStrategy
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
 
 ## Pod PriorityClass
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass


### PR DESCRIPTION
`haproxy` chart already allows you to configure update strategy for Deployment.
It would be useful to be able to do the same for DaemonSet as well.
Our use case: we'd like to fine-tune the update strategy in DaemonSet mode.