### PR TITLE
HAProxy Unified Gateway: update appVersion to 1.0.4

### DIFF
--- a/haproxy-unified-gateway/Chart.yaml
+++ b/haproxy-unified-gateway/Chart.yaml
@@ -17,7 +17,7 @@ name: haproxy-unified-gateway
 description: A Helm chart for HAProxy Unified Gateway - Kubernetes Gateway API Controller
 type: application
 version: 1.0.5
-appVersion: 1.0.3
+appVersion: 1.0.4
 kubeVersion: ">=1.26.0-0"
 keywords:
   - haproxy
@@ -37,10 +37,10 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/images: |
     - name: controller
-      image: docker.io/haproxytech/haproxy-unified-gateway:1.0.3
+      image: docker.io/haproxytech/haproxy-unified-gateway:1.0.4
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: support
       url: https://github.com/haproxytech/helm-charts/issues
   artifacthub.io/changes: |-
-    - Use HAProxy Unified Gateway 1.0.3 version for base image
+    - Use HAProxy Unified Gateway 1.0.4 version for base image


### PR DESCRIPTION
This automatic PR updates the appVersion for HAProxy Unified Gateway in Chart.yaml to 1.0.4.