### PR TITLE
fix: crdjob resources

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -78,6 +78,8 @@ spec:
           command:
             - /haproxy-ingress-controller
             - --job-check-crd
+          resources:
+            {{- toYaml .Values.crdjob.resources | nindent 12 }}
           {{- if .Values.controller.unprivileged }}
           securityContext:
             runAsNonRoot: true
@@ -93,8 +95,6 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             {{- end }}
-          resources:
-            {{- toYaml .Values.crdjob.resources | nindent 12 }}
           {{- end }}
       {{- with .Values.crdjob.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Fix wrong placement of `crdjob.resources` block.