### PR TITLE
kubernetes-ingress: add crdjob enablement configuration

### DIFF
--- a/kubernetes-ingress/templates/controller-crdjob-rbac.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob-rbac.yaml
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-
+{{- if .Values.crdjob.enabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -75,4 +75,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "kubernetes-ingress.crdjob.saName" . }}
     namespace: {{ include "kubernetes-ingress.namespace" . }}
+{{- end -}}
 {{- end -}}

--- a/kubernetes-ingress/templates/controller-crdjob.yaml
+++ b/kubernetes-ingress/templates/controller-crdjob.yaml
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- if .Values.crdjob.enabled }} 
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -108,3 +109,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/kubernetes-ingress/values.yaml
+++ b/kubernetes-ingress/values.yaml
@@ -701,6 +701,9 @@ controller:
 
 ## CRD job default values
 crdjob:
+  ## Enable or disable the CRD job
+  enabled: true
+  
   ## Additional annotations to add to the pod container metadata
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}


### PR DESCRIPTION
Make it possible to disable the crdjob, as some users will not need or want to use the crds. 